### PR TITLE
feat: make exercise catalog global with per-user exercises

### DIFF
--- a/docs/2026-08-05/2026-08-05-global-exercise-catalog.md
+++ b/docs/2026-08-05/2026-08-05-global-exercise-catalog.md
@@ -1,0 +1,119 @@
+# Global Exercise Catalog
+
+**Date:** 2026-08-05
+**Status:** Implemented (app code). Migrations written, not yet run.
+
+## Deploy order
+
+1. Run `migration-global-exercise-catalog.sql` (safe before the code ships — the old column
+   is left in place).
+2. Deploy the app.
+3. Verify personal bests, then run `migration-drop-show-in-personal-best.sql`.
+
+## Goal
+
+Turn `exercises_catalog` from a per-user table into a **shared global catalog**, while still
+letting each user add their own private exercises.
+
+## Current behaviour
+
+- `exercises_catalog` is scoped per user by RLS in Supabase. The client never filters by
+  `user_id` — every query in `exercisesCatalog.action.ts` is unscoped and relies entirely on
+  the DB policies.
+- `show_in_personal_best` is a **boolean column on the exercise row**. It is a per-user
+  preference (which exercises appear in the PR list) that only works today because each row
+  has exactly one owner.
+- `manual_personal_bests` is a separate table with its own `user_id` + RLS. **Unaffected by
+  this change.**
+
+## Decisions taken
+
+1. **Write access:** global base catalog is read-only; users can add their own private
+   exercises on top. (`user_id` stays as a nullable column: `NULL` = global, set = personal.)
+2. **PR toggle:** moves to a new per-user table. It is *not* merged into
+   `manual_personal_bests` — that table means "user typed in a PR weight" (`weight` is
+   `NOT NULL`), whereas the flag must also cover exercises with no PR at all. `fetchPersonalBests`
+   reads three independent sources (workout-derived PRs, manual PRs, and *tracked exercises with
+   no PR yet* at `personalBests.actions.ts:166`), all filtered by this flag. Overloading the
+   manual table would require a nullable `weight` and would break the `isManual` inference at
+   line 201.
+3. **UI:** one list as today, with a "Custom" badge on personal exercises.
+
+## Database migration
+
+Schema confirmed 2026-08-05:
+
+| column | type | nullable |
+|---|---|---|
+| id | text | NO |
+| name | text | NO |
+| created_at | numeric | YES |
+| category | text | NO |
+| description | text | YES |
+| user_id | uuid | **YES** |
+| show_in_personal_best | boolean | YES |
+
+Existing policy: a single `"Only you own data"` for `ALL` with `qual = (user_id = auth.uid())`.
+
+`docs/2026-08-05/migration-global-exercise-catalog.sql`:
+
+1. **No `ALTER COLUMN` needed** — `user_id` is already nullable. `NULL` = global exercise,
+   non-null = that user's private exercise.
+2. Replace the single `ALL` policy with four per-command policies. This is mandatory, not
+   cosmetic: under `ALL` with `user_id = auth.uid()`, a global row evaluates
+   `NULL = auth.uid()` → NULL → not true, so **global rows would be invisible to everyone**.
+   - `DROP POLICY "Only you own data"`
+   - SELECT: `USING (user_id IS NULL OR user_id = auth.uid())`
+   - INSERT: `WITH CHECK (user_id = auth.uid())` — cannot create global rows from the app
+   - UPDATE / DELETE: `USING (user_id = auth.uid())` — global rows immutable from the app
+3. New table `user_exercise_prefs`:
+   - `user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE`
+   - `exercise_id TEXT NOT NULL REFERENCES exercises_catalog(id) ON DELETE CASCADE`
+   - `show_in_personal_best BOOLEAN NOT NULL DEFAULT false`
+   - `UNIQUE(user_id, exercise_id)`, RLS scoped to `auth.uid() = user_id`
+4. Backfill `user_exercise_prefs` from existing `exercises_catalog.show_in_personal_best`
+   values so no user loses their current PR list.
+5. Promote the seed exercises to global (`UPDATE exercises_catalog SET user_id = NULL WHERE ...`)
+   — **selection criteria to be agreed with the user**, since dedup across users may be needed.
+6. Drop `exercises_catalog.show_in_personal_best` **only after** the app change ships.
+
+## Application changes
+
+### `src/store/exercisesCatalog/`
+- `types.ts`: `ExerciseCatalog` gains `user_id?: string | null`; `show_in_personal_best`
+  is now derived from the prefs table rather than the row. Add an `isCustom` helper.
+- `exercisesCatalog.action.ts`:
+  - `fetchExercisesCatalog` — also fetch `user_exercise_prefs` and merge the flag in.
+  - `addExercise` — set `user_id` from the session so new rows are private.
+  - `updateExercise` / `deleteExercise` — guard against global rows (the RLS will reject
+    them anyway; fail fast with a clear message instead of a silent no-op).
+  - `togglePersonalBest` — upsert into `user_exercise_prefs` instead of updating the catalog row.
+- `exercisesCatalog.mapper.ts` — merge prefs into the catalog rows.
+
+### `src/store/personalBests/personalBests.actions.ts`
+The ~8 `.eq("exercises_catalog.show_in_personal_best", true)` filters (lines 99, 144, 163,
+169, 290, and the embedded selects) must become joins/filters against `user_exercise_prefs`.
+This is the largest and riskiest part of the change. Approach: fetch the user's enabled
+exercise ids once, then filter with `.in("exercise_id", enabledIds)`.
+
+### `src/pages/exercises/Exercises.tsx` (333 lines)
+- "Custom" badge on rows where `user_id` is set.
+- Hide edit/delete actions on global exercises (lines ~126, 295, 322).
+- Keep the trophy toggle on **all** exercises — it now writes per-user prefs.
+- The file is already near the size limit in CLAUDE.md; extract the row/actions into a
+  subcomponent while touching it.
+
+## Risks / trade-offs
+
+- **Step 6 is destructive.** Dropping the column must happen only after the new code is
+  deployed, otherwise in-flight clients lose their PR filter. Two-phase deploy.
+- The personalBests query rewrite is the main source of regression risk — it touches every
+  PR surface.
+- Duplicate exercises are likely: if several users each created "Bench Press", promoting to
+  global needs a dedup + repoint of `day_exercises.exercises_catalog_id`. **Needs a decision.**
+
+## Open questions — resolved
+
+1. ~~Which exercises become global, and is dedup needed?~~ **Single user today**, so all
+   existing rows are promoted to global and no dedup / `day_exercises` repointing is required.
+2. ~~Is this a single-user app?~~ Yes, confirmed 2026-08-05.

--- a/docs/2026-08-05/migration-drop-show-in-personal-best.sql
+++ b/docs/2026-08-05/migration-drop-show-in-personal-best.sql
@@ -1,0 +1,10 @@
+-- PHASE 2 of 2. Date: 2026-08-05
+--
+-- DESTRUCTIVE. Run this ONLY after the new app code is deployed and verified.
+-- Until then the previously deployed client still reads this column, and dropping
+-- it early breaks personal bests for any open browser tab running the old bundle.
+--
+-- Verify the backfill landed before running:
+--   SELECT count(*) FROM user_exercise_prefs WHERE show_in_personal_best;
+
+ALTER TABLE exercises_catalog DROP COLUMN show_in_personal_best;

--- a/docs/2026-08-05/migration-global-exercise-catalog.sql
+++ b/docs/2026-08-05/migration-global-exercise-catalog.sql
@@ -1,0 +1,81 @@
+-- Make the exercise catalog global, with per-user private exercises on top.
+-- Date: 2026-08-05
+--
+-- PHASE 1 of 2. This file is safe to run before deploying the new app code:
+-- exercises_catalog.show_in_personal_best is left in place so the currently
+-- deployed client keeps working. Run migration-drop-show-in-personal-best.sql
+-- only after the new code is live.
+
+-- 1. Per-user preferences for which exercises appear in the personal-bests list.
+--    Kept separate from manual_personal_bests: that table means "the user typed in a
+--    PR weight" (weight is NOT NULL), while this flag must also cover exercises with
+--    no PR at all.
+CREATE TABLE IF NOT EXISTS user_exercise_prefs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  exercise_id TEXT NOT NULL REFERENCES exercises_catalog(id) ON DELETE CASCADE,
+  show_in_personal_best BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, exercise_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_exercise_prefs_user_id ON user_exercise_prefs(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_exercise_prefs_exercise_id ON user_exercise_prefs(exercise_id);
+
+ALTER TABLE user_exercise_prefs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own exercise prefs"
+  ON user_exercise_prefs FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own exercise prefs"
+  ON user_exercise_prefs FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own exercise prefs"
+  ON user_exercise_prefs FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own exercise prefs"
+  ON user_exercise_prefs FOR DELETE USING (auth.uid() = user_id);
+
+-- Reuses the trigger function created by migration-add-manual-personal-bests.sql
+CREATE TRIGGER update_user_exercise_prefs_updated_at
+  BEFORE UPDATE ON user_exercise_prefs
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- 2. Preserve every user's current PR list before the flag stops being read
+--    from exercises_catalog.
+INSERT INTO user_exercise_prefs (user_id, exercise_id, show_in_personal_best)
+SELECT user_id, id, COALESCE(show_in_personal_best, false)
+FROM exercises_catalog
+WHERE user_id IS NOT NULL
+ON CONFLICT (user_id, exercise_id) DO NOTHING;
+
+-- 3. Promote every existing exercise to the global catalog.
+--    Safe as a blanket UPDATE only because there is a single user today; with
+--    multiple users this would need dedup by name plus repointing
+--    day_exercises.exercises_catalog_id at the surviving rows.
+UPDATE exercises_catalog SET user_id = NULL;
+
+-- 4. Replace the single ALL policy with per-command policies.
+--    Required, not cosmetic: under "user_id = auth.uid()" a global row evaluates
+--    NULL = auth.uid() -> NULL -> not true, so global rows would be invisible to everyone.
+DROP POLICY IF EXISTS "Only you own data" ON exercises_catalog;
+
+CREATE POLICY "Read global and own exercises"
+  ON exercises_catalog FOR SELECT
+  USING (user_id IS NULL OR user_id = auth.uid());
+
+CREATE POLICY "Insert own exercises"
+  ON exercises_catalog FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Update own exercises"
+  ON exercises_catalog FOR UPDATE
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Delete own exercises"
+  ON exercises_catalog FOR DELETE
+  USING (user_id = auth.uid());
+
+COMMENT ON COLUMN exercises_catalog.user_id IS
+  'NULL = global exercise visible to all users and immutable from the app; set = private exercise owned by that user';
+COMMENT ON TABLE user_exercise_prefs IS
+  'Per-user settings for catalog exercises, e.g. whether an exercise appears in their personal bests';

--- a/src/pages/exercises/Exercises.tsx
+++ b/src/pages/exercises/Exercises.tsx
@@ -3,7 +3,7 @@ import { useAppDispatch, type RootState } from "../../store";
 import { exercisesCatalogActions } from "../../store/exercisesCatalog/exercisesCatalog.action";
 import { useSelector } from "react-redux";
 import { exercisesSelectors } from "../../store/exercisesCatalog/exercisesCatalog.selector";
-import type { ExerciseCatalog } from "../../store/exercisesCatalog/types";
+import { isCustomExercise, type ExerciseCatalog } from "../../store/exercisesCatalog/types";
 import { Input, Select, Dropdown } from "antd";
 import type { MenuProps } from "antd";
 import { useTranslation } from "react-i18next";
@@ -117,41 +117,51 @@ export const Exercises = () => {
         return placement;
     };
 
-    // Create dropdown menu for each exercise
-    const getDropdownMenu = (exercise: ExerciseCatalog): MenuProps => ({
-        items: [
-            {
-                key: "personal-best",
-                label: t('pages.exercises.dropdown.track_pb'),
-                icon: exercise.show_in_personal_best ? <CheckOutlined /> : <TrophyOutlined />,
-                onClick: () => {
-                    togglePersonalBest(exercise);
+    // Create dropdown menu for each exercise.
+    // Personal best tracking is per-user and available on every exercise, but editing and
+    // deleting only apply to the user's own exercises - the global catalog is read-only.
+    const getDropdownMenu = (exercise: ExerciseCatalog): MenuProps => {
+        const trackItem = {
+            key: "personal-best",
+            label: t('pages.exercises.dropdown.track_pb'),
+            icon: exercise.show_in_personal_best ? <CheckOutlined /> : <TrophyOutlined />,
+            onClick: () => {
+                togglePersonalBest(exercise);
+            },
+        };
+
+        if (!isCustomExercise(exercise)) {
+            return { items: [trackItem] };
+        }
+
+        return {
+            items: [
+                trackItem,
+                {
+                    type: "divider",
                 },
-            },
-            {
-                type: "divider",
-            },
-            {
-                key: "edit",
-                label: t('pages.exercises.dropdown.edit'),
-                icon: <EditOutlined />,
-                onClick: () => {
-                    setIsEditExerciseModalOpen(true);
-                    setSelectedExercise(exercise);
+                {
+                    key: "edit",
+                    label: t('pages.exercises.dropdown.edit'),
+                    icon: <EditOutlined />,
+                    onClick: () => {
+                        setIsEditExerciseModalOpen(true);
+                        setSelectedExercise(exercise);
+                    },
                 },
-            },
-            {
-                key: "delete",
-                label: t('pages.exercises.dropdown.delete'),
-                icon: <DeleteOutlined />,
-                danger: true,
-                onClick: () => {
-                    setIsDeleteExerciseModalOpen(true);
-                    setSelectedExercise(exercise);
+                {
+                    key: "delete",
+                    label: t('pages.exercises.dropdown.delete'),
+                    icon: <DeleteOutlined />,
+                    danger: true,
+                    onClick: () => {
+                        setIsDeleteExerciseModalOpen(true);
+                        setSelectedExercise(exercise);
+                    },
                 },
-            },
-        ],
-    });
+            ],
+        };
+    };
 
     return (
         <>
@@ -222,8 +232,15 @@ export const Exercises = () => {
                                                     )}
                                                 </div>
 
-                                                {/* Exercise Name */}
-                                                <div className="font-semibold text-[var(--text-primary)]">{exercise.name}</div>
+                                                {/* Exercise Name + Custom badge for the user's own exercises */}
+                                                <div className="flex items-center gap-2">
+                                                    <div className="font-semibold text-[var(--text-primary)]">{exercise.name}</div>
+                                                    {isCustomExercise(exercise) && (
+                                                        <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-[var(--brand-primary-light)] text-[var(--brand-primary)]">
+                                                            {t("pages.exercises.custom_badge")}
+                                                        </span>
+                                                    )}
+                                                </div>
                                             </div>
 
                                             {/* Right side: Three-dot Menu */}

--- a/src/pages/profile/Profile.tsx
+++ b/src/pages/profile/Profile.tsx
@@ -122,7 +122,8 @@ export const Profile = () => {
     return (
         <>
             <PageSEO titleKey="seo.titles.profile" descriptionKey="seo.descriptions.profile" />
-            <div className="w-full md:max-w-[1200px] m-auto flex flex-col gap-4 p-4 pb-28 md:pb-14 overflow-y-auto h-full hide-scrollbar">
+            {/* pb-40 clears the fixed BottomBar, which occupies 96px (bottom-6 + h-[72px]) */}
+            <div className="w-full md:max-w-[1200px] m-auto flex flex-col gap-4 p-4 pb-40 md:pb-14 overflow-y-auto h-full hide-scrollbar">
                 {/* Profile Header */}
                 <ProfileHeader email={email} onSettingsClick={() => setOpenSettingsModal(true)} />
 

--- a/src/store/exercisesCatalog/exercisesCatalog.action.ts
+++ b/src/store/exercisesCatalog/exercisesCatalog.action.ts
@@ -1,12 +1,34 @@
 import { createAction, createAsyncThunk } from "@reduxjs/toolkit";
-import type { AddExercisePayload, ExerciseCatalog } from "./types";
+import type { AddExercisePayload, ExerciseCatalog, UserExercisePref } from "./types";
 import { supabase } from "../supabaseClient";
 import { personalBestsActions } from "../personalBests/personalBests.actions";
+import { mergeExercisePrefs } from "./exercisesCatalog.mapper";
+import { setExerciseTracked } from "./userExercisePrefs";
+
+const getUserId = async (): Promise<string> => {
+    const { data } = await supabase.auth.getUser();
+    if (!data.user) {
+        throw new Error("Not authenticated");
+    }
+    return data.user.id;
+};
 
 const fetchExercisesCatalog = createAsyncThunk("data/fetchExercisesCatalog", async (_arg, thunkAPI) => {
     try {
-        const { data } = await supabase.from("exercises_catalog").select();
-        return data as ExerciseCatalog[];
+        // RLS returns global exercises (user_id is null) plus the user's own ones.
+        const [catalogResult, prefsResult] = await Promise.all([
+            supabase.from("exercises_catalog").select(),
+            supabase.from("user_exercise_prefs").select("exercise_id, show_in_personal_best"),
+        ]);
+
+        if (catalogResult.error) {
+            return thunkAPI.rejectWithValue(catalogResult.error.message);
+        }
+        if (prefsResult.error) {
+            return thunkAPI.rejectWithValue(prefsResult.error.message);
+        }
+
+        return mergeExercisePrefs((catalogResult.data ?? []) as ExerciseCatalog[], (prefsResult.data ?? []) as UserExercisePref[]);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
         return thunkAPI.rejectWithValue(error.message);
@@ -15,7 +37,17 @@ const fetchExercisesCatalog = createAsyncThunk("data/fetchExercisesCatalog", asy
 
 const addExercise = createAsyncThunk("data/addExercise", async (exercise: AddExercisePayload, thunkAPI) => {
     try {
-        const { data } = await supabase.from("exercises_catalog").insert([exercise]).select();
+        // Stamped with the current user so it stays private; only global rows have a null user_id.
+        const userId = await getUserId();
+        const { data, error } = await supabase
+            .from("exercises_catalog")
+            .insert([{ ...exercise, user_id: userId }])
+            .select();
+
+        if (error) {
+            return thunkAPI.rejectWithValue(error.message);
+        }
+
         return data as ExerciseCatalog[];
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
@@ -25,7 +57,17 @@ const addExercise = createAsyncThunk("data/addExercise", async (exercise: AddExe
 
 const updateExercise = createAsyncThunk("data/updateExercise", async (exercise: AddExercisePayload, thunkAPI) => {
     try {
-        const { data } = await supabase.from("exercises_catalog").update(exercise).eq("id", exercise.id).select();
+        const { data, error } = await supabase.from("exercises_catalog").update(exercise).eq("id", exercise.id).select();
+
+        if (error) {
+            return thunkAPI.rejectWithValue(error.message);
+        }
+
+        // RLS silently matches no rows when the exercise is global, so report it explicitly.
+        if (!data || data.length === 0) {
+            return thunkAPI.rejectWithValue("Global catalog exercises cannot be edited");
+        }
+
         return data as ExerciseCatalog[];
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
@@ -35,7 +77,16 @@ const updateExercise = createAsyncThunk("data/updateExercise", async (exercise: 
 
 const deleteExercise = createAsyncThunk("data/deleteExercise", async (id: string, thunkAPI) => {
     try {
-        await supabase.from("exercises_catalog").delete().eq("id", id);
+        const { data, error } = await supabase.from("exercises_catalog").delete().eq("id", id).select();
+
+        if (error) {
+            return thunkAPI.rejectWithValue(error.message);
+        }
+
+        if (!data || data.length === 0) {
+            return thunkAPI.rejectWithValue("Global catalog exercises cannot be deleted");
+        }
+
         return id;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
@@ -47,26 +98,15 @@ const togglePersonalBest = createAsyncThunk(
     "data/togglePersonalBest",
     async (payload: { id: string; showInPersonalBest: boolean }, thunkAPI) => {
         try {
-            // Update the exercises_catalog table
-            const { data, error } = await supabase
-                .from("exercises_catalog")
-                .update({ show_in_personal_best: payload.showInPersonalBest })
-                .eq("id", payload.id)
-                .select();
-
-            if (error) {
-                return thunkAPI.rejectWithValue(error.message);
-            }
-
-            if (!data || data.length === 0) {
-                return thunkAPI.rejectWithValue("No data returned from update");
-            }
+            // Per-user preference: written to user_exercise_prefs rather than to the shared
+            // catalog row, so one user's choice cannot affect anyone else.
+            await setExerciseTracked(payload.id, payload.showInPersonalBest);
 
             // Refresh personal bests state to reflect the changes
-            // Manual PRs are kept in the database but filtered out by show_in_personal_best
+            // Manual PRs are kept in the database but filtered out by the preference
             await thunkAPI.dispatch(personalBestsActions.fetchPersonalBests());
 
-            return data as ExerciseCatalog[];
+            return payload;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             return thunkAPI.rejectWithValue(error.message);

--- a/src/store/exercisesCatalog/exercisesCatalog.mapper.ts
+++ b/src/store/exercisesCatalog/exercisesCatalog.mapper.ts
@@ -1,0 +1,15 @@
+import type { ExerciseCatalog, UserExercisePref } from "./types";
+
+/**
+ * The catalog is shared across users, so `show_in_personal_best` cannot live on the
+ * exercise row. It comes from the per-user `user_exercise_prefs` table and is merged
+ * onto each exercise here. Exercises with no pref row default to false.
+ */
+export const mergeExercisePrefs = (exercises: ExerciseCatalog[], prefs: UserExercisePref[]): ExerciseCatalog[] => {
+    const prefsByExerciseId = new Map(prefs.map((pref) => [pref.exercise_id, pref.show_in_personal_best]));
+
+    return exercises.map((exercise) => ({
+        ...exercise,
+        show_in_personal_best: prefsByExerciseId.get(exercise.id) ?? false,
+    }));
+};

--- a/src/store/exercisesCatalog/exercisesCatalog.reducer.ts
+++ b/src/store/exercisesCatalog/exercisesCatalog.reducer.ts
@@ -28,7 +28,8 @@ export const exercisesReducer = {
             })
             .addCase(exercisesCatalogActions.addExercise.fulfilled, (state, action) => {
                 state.isLoading = false;
-                state.exercises = [...state.exercises, action.payload[0]];
+                // New exercises have no prefs row yet, so they start untracked.
+                state.exercises = [...state.exercises, { ...action.payload[0], show_in_personal_best: false }];
             })
             .addCase(exercisesCatalogActions.addExercise.rejected, (state) => {
                 state.isLoading = false;
@@ -61,9 +62,11 @@ export const exercisesReducer = {
             })
             .addCase(exercisesCatalogActions.togglePersonalBest.fulfilled, (state, action) => {
                 state.isLoading = false;
-                if (action.payload && action.payload.length > 0) {
-                    state.exercises = [...state.exercises.map((exercise) => (exercise.id === action.payload[0].id ? action.payload[0] : exercise))];
-                }
+                // The preference lives in user_exercise_prefs now, so patch the flag in place
+                // rather than replacing the (shared) catalog row.
+                state.exercises = state.exercises.map((exercise) =>
+                    exercise.id === action.payload.id ? { ...exercise, show_in_personal_best: action.payload.showInPersonalBest } : exercise,
+                );
             })
             .addCase(exercisesCatalogActions.togglePersonalBest.rejected, (state, action) => {
                 state.isLoading = false;

--- a/src/store/exercisesCatalog/types.ts
+++ b/src/store/exercisesCatalog/types.ts
@@ -11,6 +11,9 @@ export interface ExerciseCatalog {
     category: string;
     description?: string;
     created_at?: number;
+    /** null for global catalog exercises, set for a user's own private exercise */
+    user_id?: string | null;
+    /** Per-user preference, merged in from user_exercise_prefs (not a column on the row) */
     show_in_personal_best?: boolean;
 }
 
@@ -20,3 +23,11 @@ export interface AddExercisePayload {
     category: string;
     description?: string;
 }
+
+export interface UserExercisePref {
+    exercise_id: string;
+    show_in_personal_best: boolean;
+}
+
+/** Global exercises are read-only from the app; only a user's own exercises can be edited. */
+export const isCustomExercise = (exercise: ExerciseCatalog): boolean => !!exercise.user_id;

--- a/src/store/exercisesCatalog/userExercisePrefs.ts
+++ b/src/store/exercisesCatalog/userExercisePrefs.ts
@@ -1,0 +1,38 @@
+import { supabase } from "../supabaseClient";
+
+/**
+ * Ids of the exercises the current user tracks in their personal bests.
+ *
+ * The catalog is shared, so this preference cannot be a column on the exercise row and
+ * cannot be filtered inside a join. Callers fetch the ids once and filter with them.
+ */
+export const fetchTrackedExerciseIds = async (): Promise<string[]> => {
+    const { data, error } = await supabase.from("user_exercise_prefs").select("exercise_id").eq("show_in_personal_best", true);
+
+    if (error) {
+        throw new Error(error.message || "Error fetching tracked exercises");
+    }
+
+    return (data ?? []).map((pref) => pref.exercise_id as string);
+};
+
+/** Turn a tracked exercise on or off for the current user. */
+export const setExerciseTracked = async (exerciseId: string, tracked: boolean): Promise<void> => {
+    const { data } = await supabase.auth.getUser();
+    if (!data.user) {
+        throw new Error("User not authenticated");
+    }
+
+    const { error } = await supabase.from("user_exercise_prefs").upsert(
+        {
+            user_id: data.user.id,
+            exercise_id: exerciseId,
+            show_in_personal_best: tracked,
+        },
+        { onConflict: "user_id,exercise_id" },
+    );
+
+    if (error) {
+        throw new Error(error.message || "Error updating tracked exercise");
+    }
+};

--- a/src/store/personalBests/personalBests.actions.ts
+++ b/src/store/personalBests/personalBests.actions.ts
@@ -2,12 +2,16 @@ import { createAsyncThunk } from "@reduxjs/toolkit";
 import { supabase } from "../supabaseClient";
 import type { PersonalBest, PersonalBestsWorkoutResponse } from "./types";
 import { exercisesCatalogActions } from "../exercisesCatalog/exercisesCatalog.action";
+import { fetchTrackedExerciseIds, setExerciseTracked } from "../exercisesCatalog/userExercisePrefs";
 
 /**
  * Process workout data to extract personal bests
  * Groups all weights by exercise and finds the maximum for each
+ *
+ * `trackedExerciseIds` comes from the current user's preferences: the catalog is shared,
+ * so tracking can no longer be read off the exercise row or filtered inside the join.
  */
-function processPersonalBests(workouts: PersonalBestsWorkoutResponse[]): PersonalBest[] {
+function processPersonalBests(workouts: PersonalBestsWorkoutResponse[], trackedExerciseIds: Set<string>): PersonalBest[] {
     const exerciseWeights = new Map<
         string,
         {
@@ -33,10 +37,9 @@ function processPersonalBests(workouts: PersonalBestsWorkoutResponse[]): Persona
                 const exerciseId = typedDayEx.exercises_catalog.id;
                 const exerciseName = typedDayEx.exercises_catalog.name;
                 const category = typedDayEx.exercises_catalog.category;
-                const showInPersonalBest = typedDayEx.exercises_catalog.show_in_personal_best;
 
-                // Only process exercises marked for personal best tracking
-                if (!showInPersonalBest) return;
+                // Only process exercises the user tracks for personal bests
+                if (!trackedExerciseIds.has(exerciseId)) return;
                 if (!exerciseId || !exerciseName || !category) return;
                 if (!typedDayEx.day_exercise_sets || !Array.isArray(typedDayEx.day_exercise_sets)) return;
 
@@ -76,6 +79,11 @@ const fetchWorkoutPersonalBests = createAsyncThunk(
     "personalBests/fetchWorkoutPersonalBests",
     async (_arg, thunkAPI) => {
         try {
+            const trackedExerciseIds = await fetchTrackedExerciseIds();
+            if (trackedExerciseIds.length === 0) {
+                return [];
+            }
+
             const { data, error } = await supabase
                 .from("workouts")
                 .select(
@@ -85,8 +93,7 @@ const fetchWorkoutPersonalBests = createAsyncThunk(
                         exercises_catalog!inner (
                             id,
                             name,
-                            category,
-                            show_in_personal_best
+                            category
                         ),
                         day_exercise_sets (
                             weight
@@ -96,7 +103,7 @@ const fetchWorkoutPersonalBests = createAsyncThunk(
             `
                 )
                 .in("status", ["archived", "published"])
-                .eq("days.day_exercises.exercises_catalog.show_in_personal_best", true);
+                .in("days.day_exercises.exercises_catalog.id", trackedExerciseIds);
 
             if (error) {
                 throw new Error("Error fetching workout personal bests");
@@ -106,7 +113,7 @@ const fetchWorkoutPersonalBests = createAsyncThunk(
                 return [];
             }
 
-            return processPersonalBests(data as PersonalBestsWorkoutResponse[]);
+            return processPersonalBests(data as PersonalBestsWorkoutResponse[], new Set(trackedExerciseIds));
         } catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : "Unknown error";
             return thunkAPI.rejectWithValue(errorMessage);
@@ -120,6 +127,12 @@ const fetchWorkoutPersonalBests = createAsyncThunk(
  */
 const fetchPersonalBests = createAsyncThunk("personalBests/fetchPersonalBests", async (_arg, thunkAPI) => {
     try {
+        // The user's tracked exercises drive all three sources below.
+        const trackedExerciseIds = await fetchTrackedExerciseIds();
+        if (trackedExerciseIds.length === 0) {
+            return [];
+        }
+
         // Fetch workout-derived PRs
         const workoutPRsPromise = supabase
             .from("workouts")
@@ -130,8 +143,7 @@ const fetchPersonalBests = createAsyncThunk("personalBests/fetchPersonalBests", 
                         exercises_catalog!inner (
                             id,
                             name,
-                            category,
-                            show_in_personal_best
+                            category
                         ),
                         day_exercise_sets (
                             weight
@@ -141,9 +153,9 @@ const fetchPersonalBests = createAsyncThunk("personalBests/fetchPersonalBests", 
             `
             )
             .in("status", ["archived", "published"])
-            .eq("days.day_exercises.exercises_catalog.show_in_personal_best", true);
+            .in("days.day_exercises.exercises_catalog.id", trackedExerciseIds);
 
-        // Fetch manual PRs (only for exercises with show_in_personal_best = true)
+        // Fetch manual PRs (only for tracked exercises)
         const manualPRsPromise = supabase
             .from("manual_personal_bests")
             .select(
@@ -155,18 +167,14 @@ const fetchPersonalBests = createAsyncThunk("personalBests/fetchPersonalBests", 
                 exercises_catalog!inner (
                     id,
                     name,
-                    category,
-                    show_in_personal_best
+                    category
                 )
             `
             )
-            .eq("exercises_catalog.show_in_personal_best", true);
+            .in("exercise_id", trackedExerciseIds);
 
-        // Fetch all exercises with show_in_personal_best = true
-        const trackedExercisesPromise = supabase
-            .from("exercises_catalog")
-            .select("id, name, category")
-            .eq("show_in_personal_best", true);
+        // Fetch the tracked exercises themselves, so ones with no PR yet still render
+        const trackedExercisesPromise = supabase.from("exercises_catalog").select("id, name, category").in("id", trackedExerciseIds);
 
         const [workoutResult, manualResult, trackedExercisesResult] = await Promise.all([
             workoutPRsPromise,
@@ -187,7 +195,7 @@ const fetchPersonalBests = createAsyncThunk("personalBests/fetchPersonalBests", 
         }
 
         // Process workout PRs
-        const workoutPRs = processPersonalBests((workoutResult.data || []) as PersonalBestsWorkoutResponse[]);
+        const workoutPRs = processPersonalBests((workoutResult.data || []) as PersonalBestsWorkoutResponse[], new Set(trackedExerciseIds));
 
         // Process manual PRs
         const manualPRs: PersonalBest[] = (manualResult.data || []).map((item) => {
@@ -271,6 +279,11 @@ const fetchManualPersonalBests = createAsyncThunk(
     "personalBests/fetchManualPersonalBests",
     async (_arg, thunkAPI) => {
         try {
+            const trackedExerciseIds = await fetchTrackedExerciseIds();
+            if (trackedExerciseIds.length === 0) {
+                return [];
+            }
+
             const { data, error } = await supabase
                 .from("manual_personal_bests")
                 .select(
@@ -282,12 +295,11 @@ const fetchManualPersonalBests = createAsyncThunk(
                     exercises_catalog!inner (
                         id,
                         name,
-                        category,
-                        show_in_personal_best
+                        category
                     )
                 `
                 )
-                .eq("exercises_catalog.show_in_personal_best", true)
+                .in("exercise_id", trackedExerciseIds)
                 .order("weight", { ascending: false });
 
             if (error) {
@@ -335,15 +347,9 @@ const addManualPersonalBest = createAsyncThunk(
                 throw new Error("User not authenticated");
             }
 
-            // Update the exercise to be tracked in personal bests
-            const { error: updateError } = await supabase
-                .from("exercises_catalog")
-                .update({ show_in_personal_best: true })
-                .eq("id", payload.exerciseId);
-
-            if (updateError) {
-                throw new Error(updateError.message || "Error updating exercise catalog");
-            }
+            // Mark the exercise as tracked for this user. Written to their preferences, not
+            // to the shared catalog row.
+            await setExerciseTracked(payload.exerciseId, true);
 
             const { data, error } = await supabase
                 .from("manual_personal_bests")

--- a/src/utils/i18n/en.json
+++ b/src/utils/i18n/en.json
@@ -152,6 +152,7 @@
         "exercises": {
             "title": "Exercises",
             "meta_title": "Exercises | GymTracker",
+            "custom_badge": "Custom",
             "dropdown": {
                 "track_pb": "Track in Personal Bests",
                 "edit": "Edit",

--- a/src/utils/i18n/es.json
+++ b/src/utils/i18n/es.json
@@ -152,6 +152,7 @@
         "exercises": {
             "title": "Ejercicios",
             "meta_title": "Ejercicios | GymTracker",
+            "custom_badge": "Personalizado",
             "dropdown": {
                 "track_pb": "Rastrear en Mejores Marcas",
                 "edit": "Editar",

--- a/src/utils/i18n/it.json
+++ b/src/utils/i18n/it.json
@@ -152,6 +152,7 @@
         "exercises": {
             "title": "Esercizi",
             "meta_title": "Esercizi | GymTracker",
+            "custom_badge": "Personalizzato",
             "dropdown": {
                 "track_pb": "Traccia nei Record Personali",
                 "edit": "Modifica",


### PR DESCRIPTION
The exercise catalog was scoped per user via RLS. It is now a shared global catalog (user_id IS NULL) that every user can read, while users can still add their own private exercises on top.

show_in_personal_best could not stay as a column on the exercise row: it is a per-user preference, and on a shared row one user's toggle would change what everyone sees in their personal bests. It moves to a new user_exercise_prefs table with its own RLS, merged onto the catalog at fetch time. Absence of a prefs row means "not tracked", so rows are only written when a user actually opts in.

Kept separate from manual_personal_bests deliberately: that table means "the user typed in a PR weight" (weight is NOT NULL), whereas this flag must also cover tracked exercises with no PR at all.

The RLS change replaces the single ALL policy with four per-command policies. This is required, not cosmetic: under "user_id = auth.uid()" a global row evaluates NULL = auth.uid() -> NULL, so global rows would have been invisible to everyone.

Migrations are split in two phases. Phase 1 is safe to run before deploying; dropping the old column must wait until this code is live, or clients running the old bundle lose their PR filtering.

Also bumps Profile's bottom padding to pb-40 so personal bests clear the fixed BottomBar, which occupies 96px (bottom-6 + h-[72px]).