### PR TITLE
fix: add vertical padding to the profile header

### DIFF
--- a/src/pages/profile/components/ProfileHeader.tsx
+++ b/src/pages/profile/components/ProfileHeader.tsx
@@ -10,7 +10,7 @@ interface ProfileHeaderProps {
 export const ProfileHeader = ({ email, onSettingsClick }: ProfileHeaderProps) => {
     const { t } = useTranslation();
     return (
-        <div className="flex justify-between items-center">
+        <div className="flex justify-between items-center py-4">
             {/* User Info */}
             <div className="flex items-center gap-4">
                 {/* Avatar */}


### PR DESCRIPTION
Gives the profile page enough height to overflow the viewport on a phone, so the content scrolls and the personal bests table is no longer left sitting behind the fixed bottom bar.