### PR TITLE
feat: track weight and reps progression per training session

### DIFF
--- a/docs/2026-08-05/2026-08-05-training-session-progression.md
+++ b/docs/2026-08-05/2026-08-05-training-session-progression.md
@@ -1,0 +1,338 @@
+# Training session progression (weight + reps history)
+
+Date: 2026-08-05
+Status: **implemented** (migration not yet run against Supabase)
+
+## Problem
+
+The plan and the record are the same object.
+
+`day_exercise_sets` holds `reps` (target, free text), `weight` (current) and `base_weight` (initial).
+Every training the user overwrites `weight` in place, so each session destroys the previous one.
+The only trace that a session happened is `days.counter` (how many times) and `days.last_workout`
+(when, last time) — set in `CurrentExercisesList.handleStartClick`.
+
+Consequences:
+
+- Weight progression is limited to two points: `base_weight` and `weight`.
+- **Reps progression does not exist at all.** `day_exercise_sets.reps` is a prescription
+  (`"8-10"`, `"Max"`, seconds), never a record of what was performed.
+- Personal bests are computed by scanning the *plan* (`personalBests.actions.ts` walks
+  `days -> day_exercises -> day_exercise_sets`), so a PR disappears the moment the user
+  lowers the weight in the plan.
+
+## Decision
+
+Keep `workout -> day -> day_exercise -> day_exercise_sets` exactly as it is and demote it to what
+it already is: **the template / prescription**. Add an append-only log beside it.
+
+Rejected alternative: versioning `day_exercise_sets` itself (soft-delete + `valid_from`). It makes
+every existing read path filter on validity, and the plan legitimately changes for reasons unrelated
+to training (reordering, renaming, adding a set) which would pollute the history.
+
+### New tables
+
+```
+day_sessions
+  id              uuid pk
+  user_id         uuid   -> auth.users
+  workout_id      uuid   -> workouts
+  day_id          uuid   -> days
+  session_number  int          -- 1st, 2nd, 3rd training of this day
+  started_at      timestamptz
+  completed_at    timestamptz  -- nullable, set when the user leaves/finishes
+  notes           text
+
+session_sets
+  id               uuid pk
+  session_id       uuid -> day_sessions (cascade)
+  day_exercise_id  uuid -> day_exercises (cascade)
+  set_number       int
+  weight           numeric   -- actual performed
+  reps             int       -- actual performed, nullable
+  reps_raw         text      -- exactly what the user typed, always kept
+  target_reps      text      -- snapshot of the plan's prescription at that moment
+  reps_type        text      -- snapshot: reps | time | max | custom
+```
+
+### Why these columns
+
+**`day_exercise_id`, not `set_id`.** Sets are added, removed and renumbered over time
+(`addSet`/`removeSet` in `ExerciseContent.tsx`). Pointing history at a set row means history breaks
+on delete, or silently re-points when the plan is edited. The pair
+`(day_exercise_id, set_number)` is the stable identity for a logged set.
+
+**`reps` + `reps_raw`.** Charting reps needs a number, but `reps_type` guarantees we won't always
+get one:
+
+| `reps_type` | plan value means | logged value means | chartable |
+|---|---|---|---|
+| `reps` | target reps, often a range `"8-10"` | reps actually performed | yes |
+| `time` | seconds to hold | seconds actually held | yes (as seconds) |
+| `max` | literally `"Max"` | reps achieved — the whole point | yes |
+| `custom` | free text | free text | no, table only |
+
+So: parse into `reps` when possible, always persist `reps_raw`, and chart only rows where
+`reps` is non-null.
+
+**`reps_type` and `target_reps` are snapshotted per session.** An exercise can be switched from
+`reps` to `time` later; without the snapshot every historical row silently changes meaning.
+
+### Pre-fill rule (as requested)
+
+On starting a session, `session_sets` rows are seeded from:
+
+- `weight` <- `day_exercise_sets.weight` (already "last performed", see write-back below)
+- `reps`  <- **the previous session's actual reps** for the same
+  `(day_exercise_id, set_number)`, *not* the plan's target
+
+Rationale: the user wants last session's `8` pre-filled, not the plan's `"8-10"`. On the first ever
+session there is no prior, so reps starts empty with `target_reps` shown as placeholder.
+
+### Write-back
+
+On save, the session row is authoritative, **and** `day_exercise_sets.weight` is updated to the
+performed weight. This is a deliberate denormalised "last performed" cache: it keeps every existing
+read path (current workout, history, exercise card) working unchanged and makes the log purely
+additive. `day_exercise_sets.reps` is *not* written back — it stays the target.
+
+### Fields that become derived
+
+| Field | Becomes |
+|---|---|
+| `day_exercise_sets.base_weight` | first session's weight |
+| `days.counter` | `count(*)` over `day_sessions` |
+| `days.last_workout` | `max(started_at)` over `day_sessions` |
+
+None are dropped in this change. They keep being written so a rollback is possible; a follow-up
+migration removes them once the new code is proven live (same two-phase pattern as
+`migration-global-exercise-catalog.sql`).
+
+The "save as base weight" flow (`currentActions.saveBaseWeight`, the confirm modal in
+`CurrentExercisesList.tsx:40`) becomes meaningless and is removed from the UI.
+
+## Backfill, and what is lost
+
+`migration-training-sessions.sql` synthesises at most **two** sessions per exercise from existing
+data: session 1 from `base_weight`, session N from `weight` (skipped when they are equal or null).
+Everything between them is unrecoverable, and **no reps history can be reconstructed** because reps
+was never recorded. Reps progression starts from zero on migration day for every user. This is
+stated up front because it is not fixable later.
+
+## Implementation plan
+
+### 1. Database — `docs/2026-08-05/migration-training-sessions.sql`
+
+Two tables above, RLS policies per command (`auth.uid() = user_id`, session_sets via the parent
+session), indexes on `(day_id, session_number)` and `(day_exercise_id)`, and the backfill.
+
+### 2. New store slice — `src/store/sessions/`
+
+Following the existing slice pattern exactly:
+
+- `types.ts` — `DaySession`, `SessionSet`, payload types, response types
+- `sessions.mapper.ts` — snake_case -> camelCase, plus the `reps_raw` -> `reps` parse
+- `sessions.actions.ts` — `startSession`, `updateSessionSet`, `completeSession`,
+  `fetchSessionsForDay`, `fetchProgressionForExercise`
+- `sessions.reducer.ts`, `sessions.selectors.ts`
+- registered in `reducer.config.ts`, cleared by `RESET_STORE`
+
+Reps parsing lives in `src/utils/reps.ts` (`parseReps(raw, repsType): number | null`) so the mapper
+and the chart share one implementation.
+
+### 3. Session lifecycle — `src/pages/workouts/current/components/CurrentExercisesList.tsx`
+
+`handleStartClick` currently only stamps the day. It becomes: create a `day_sessions` row + seed
+`session_sets`, *and* keep the existing `days` update for the derived-field compatibility window.
+The implicit start inside `saveExercises` (line 84) is preserved.
+
+### 4. The invasive bit — `src/pages/workouts/components/exerciseContent/ExerciseContent.tsx`
+
+`updateSet` (line 112) writes the plan today. It must branch on mode:
+
+- `isDraft` -> unchanged, writes `day_exercise_sets` (the plan)
+- `isCurrent` -> writes `session_sets` for the active session; weight additionally writes back to
+  `day_exercise_sets.weight`
+- `isHistory` -> read-only, unchanged
+
+The component is already polymorphic on these props, so this is the natural seam — but it is the
+single most delicate edit in the change. The reps `Input` (line 260) stops being read-only for
+`repsType === "max"` in current mode: logging the reps achieved is exactly what `max` is for.
+
+### 5. Progression UI
+
+New `ExerciseProgression` component under
+`src/pages/workouts/components/exerciseContent/`, opened from the exercise card:
+
+- a table of sessions (date, per-set weight x reps) — always available, the only view for `custom`
+- a Recharts line chart of weight and reps over sessions — only when `reps` is non-null
+
+Per the dataviz guidance, the chart is added only where it is actually readable; `custom` and
+mixed-type exercises fall back to the table.
+
+### 6. Personal bests — `src/store/personalBests/personalBests.actions.ts`
+
+Recomputed as `max(weight)` over `session_sets` instead of walking the plan. This removes the
+`any[]` nested-scan (`PersonalBestsWorkoutResponse`) and fixes the bug where lowering a plan weight
+erases a PR. Manual PRs are untouched.
+
+### 7. i18n
+
+New keys in `en.json` / `it.json` / `es.json` for the progression view. Run the `translations`
+skill at the end.
+
+## Rollout order
+
+1. Run the migration (safe against currently deployed code — additive only).
+2. Ship the app change.
+3. Later, a phase-2 migration drops `base_weight` / `days.counter` / `days.last_workout`.
+
+## Decisions taken (approved 2026-08-05)
+
+1. **Session granularity** — one `day_sessions` row per day started, i.e. an entire training.
+2. **Same day twice** — `isAlreadyStarted` keeps no-opping a second start on the same calendar day.
+3. **Editing past sessions** — read-only. Correcting a mistyped weight is a follow-up.
+
+## What changed during implementation
+
+- **`Set.targetReps` added** (`src/store/draft/types.ts`). In current mode `set.reps` is overlaid
+  with the *performed* value from the active session so the bound input never changes shape, and
+  `targetReps` carries the plan's prescription into the placeholder. Without this the component
+  would have needed two parallel set shapes.
+- **Stale-selector fix in `saveExercises`.** A save that implicitly opens a session cannot read the
+  new id from the selector — the fetch has not landed yet — so `handleStartClick` returns the id
+  from the thunk and the save uses that.
+- **`max` reps are now editable in current mode.** Previously `readOnly`; logging the reps achieved
+  is precisely what that reps type is for.
+- **`currentActions.saveBaseWeight` deleted** along with its confirm modal and the
+  `confirm_save_base` / `initial` translation keys. The "Initial" tooltip in the exercise card is
+  replaced by the **Progression** button that opens the new view. `base_weight` is still written by
+  `draftActions` and still read on the type, so phase 2 can drop it cleanly.
+- **Progression lives under**
+  `src/pages/workouts/components/exerciseContent/progression/`: `ExerciseProgression` (container +
+  fetch), `ExerciseProgressionTable`, `progression.utils.ts`.
+- **The chart was built, then removed on request.** It plotted the heaviest set per session with
+  weight and reps on separate axes. `ExerciseProgressionChart.tsx` is deleted; `groupBySession`
+  still computes `topWeight` / `topReps` and `progression.utils.ts` still exports
+  `hasChartableWeight` / `hasChartableReps`, which are currently unused but are exactly what a
+  reinstated chart needs. Delete them if the chart is not coming back.
+- **`parseReps` rejects ranges** (`"8-10"`). A range is a prescription; if it survives into a log it
+  means nothing was actually recorded, so there is nothing to chart. `reps_raw` still keeps it.
+- **`PersonalBestsWorkoutResponse` removed.** The nested `any[]` plan scan is gone; PRs are now a
+  flat `max(weight)` over `session_sets`.
+
+### Set row redesigned (second review)
+
+`addonAfter` was still ambiguous — antd renders addons as bordered, field-height blocks sharing the
+input's bounding box, so the target read as "another number glued to the field" rather than as
+reference information. The row is now a four-column grid:
+
+```
+ SET  TARGET   REPS              KG
+ (1)   8-10   [ 9          ]   [ 80      kg ]
+```
+
+The organising rule: **the boxed treatment is reserved for editable values**. Set number and target
+are flat text with no border; performed reps and weight are boxed with border, elevated fill and
+shadow. History mode drops the boxes via a class ternary, so the same DOM degrades to four columns
+of flat text with identical alignment.
+
+Static labels are hoisted into a header rendered **once per exercise** (`SetRowHeader`), not per
+set — ~18px once instead of ~32px on every row, which is what buys the target its own column
+without growing a 5-set exercise. Shared grid template and input classes live in
+`setRow.styles.ts` so the header and rows cannot drift apart.
+
+Details worth keeping:
+- Inputs are `h-11` (44px, WCAG 2.5.5) at 16px text — below 16px iOS Safari zooms on focus.
+- `tabular-nums` everywhere numeric, so digits don't shift width while typing.
+- The target uses `--text-secondary`, never `--text-tertiary`: tertiary computes to ~2.8:1 on
+  `--bg-elevated` in light mode and fails AA.
+- The set badge uses `--bg-tertiary`, not the spec's `--bg-secondary`, because in dark mode
+  `--bg-secondary` and `--bg-elevated` are both `#262626` and the badge would vanish.
+- Weight unit moved from `addonBefore` to `suffix`, so the eye lands on the number before the unit.
+- The set number badge is `aria-hidden` (duplicated in each input's `aria-label`), and the target is
+  linked with `aria-describedby` so it is announced as a description after the value, not as the
+  label.
+
+### Wrong-session write (final check)
+
+`getActiveSession` returns the newest session with no `completed_at`, and **nothing ever dispatches
+`completeSession`**, so every session stays open indefinitely. `saveExercises` took the session id
+straight from that selector, so on a new training day the first edit made *before* pressing Start
+was written into the previous session — silently corrupting a past entry rather than opening a new
+one.
+
+Whether today has started now comes from `isAlreadyStarted()` (the day's `last_workout`), which is
+the same signal the Start button uses. When today has started the id comes from the selector; when
+it has not, a session is opened and its id comes back from the thunk.
+
+Left as-is, deliberately: `completeSession` is wired through the actions/reducer but never
+dispatched, so sessions have no end. Nothing depends on it now that session choice is driven by
+`last_workout`, but it is the natural hook if an explicit "finish workout" action is ever added.
+`hasChartableWeight` / `hasChartableReps` are likewise unused, kept for a reinstated chart.
+
+### `custom` reps type withdrawn (fourth review)
+
+`custom` is removed from `RepsTypes`, so it can no longer be selected for a new or edited exercise.
+
+It is **not** deleted from the codebase. Exercises created while it existed still have
+`reps_type = 'custom'` and their content lives in `custom_type`, which no other view renders — if
+the branch were removed those exercises would display as blank. The textarea is therefore kept but
+made read-only: legacy content stays readable, nothing new can be written to it.
+
+The `custom` arm in `parseReps` and the `RepsType` union also stay, for the same reason.
+
+Full removal (dropping the branch, the `customType` field, and the `custom_type` column) is safe
+only once `SELECT count(*) FROM day_exercises WHERE reps_type = 'custom'` returns 0.
+
+### `time` and `max` have no separate weight (third review)
+
+The four-column grid assumed every exercise has reps *and* a weight. It doesn't: only `repsType`
+= `reps` does. For `time` the performed value is seconds and for `max` it is the reps achieved,
+and **both have always been stored in the weight column**, with `getAddon()` relabelling the unit.
+The redesign therefore rendered an empty duplicate input and the header "SECS" twice for timed
+exercises.
+
+`hasSeparateWeight(repsType)` now gates this: `reps` keeps four columns, `time` and `max` collapse
+to three (set / target / value), with the value column carrying its own unit label and taking over
+the `aria-describedby` link to the target. `getSetGrid(repsType)` returns the matching template so
+the header and rows stay aligned.
+
+Same assumption was wrong in the progression table, which hardcoded "Kg" — it now uses
+`getValueUnitKey(repsType)` (`reps` → kg, `time` → secs, `max` → reps). The old `getRepsUnitKey`
+helper was unused and is replaced by it.
+
+Not addressed: a weighted plank or a weighted max-reps set has nowhere to record its load. That
+limitation predates this work.
+
+### Target reps stay visible (fixed after first review)
+
+The target was first rendered as the reps input's `placeholder`. That only works on the very first
+session: from the second onward the field is pre-filled with the previous session's reps, so the
+placeholder never renders and the user permanently loses sight of what they planned.
+
+It now sits in `addonAfter`, always visible next to the number performed, and the reps/weight
+columns are 50/50 instead of 40/60 to fit a range like `8-10`. The data was never at risk — the
+plan's target is written back untouched and snapshotted into `session_sets.target_reps` — this was
+purely a display defect.
+
+Related hardening: the write-back now skips any set whose `targetReps` is undefined instead of
+upserting it, so the prescription can never be blanked by a save.
+
+### Schema correction (found while running the migration)
+
+The "all ids are uuid" assumption was wrong. `workouts.id`, `days.id`, `days.workout_id`,
+`day_exercises.id`, `day_exercises.day_id`, `day_exercise_sets.id` and
+`day_exercise_sets.day_exercise_id` are all **TEXT** — the client generates them with `uuidv4()`
+and they are stored as text. `day_sessions.id`, `.workout_id`, `.day_id` and `session_sets.id`,
+`.session_id`, `.day_exercise_id` are TEXT accordingly, defaulting to `uuid_generate_v4()::text`.
+`user_id` stays UUID, since `auth.users.id` is UUID.
+
+The backfill's date expressions also cast through `::text` and branch on whether the value is all
+digits, because `days.created_at` may be a timestamp while `days.last_workout` is an epoch in
+milliseconds, and the storage type of each was not established.
+
+### Verification
+
+`tsc --noEmit` clean, `npm run build` succeeds, `npm run lint` unchanged from baseline
+(22 pre-existing errors, none in the new files).

--- a/docs/2026-08-05/migration-training-sessions.sql
+++ b/docs/2026-08-05/migration-training-sessions.sql
@@ -1,0 +1,170 @@
+-- Track every training as its own row, so weight AND reps progression can be charted.
+-- Date: 2026-08-05
+--
+-- PHASE 1 of 2. Safe to run before deploying the new app code: this file is purely
+-- additive. day_exercise_sets.base_weight, days.counter and days.last_workout are
+-- left in place and keep being written by the new code, so a rollback stays possible.
+-- A later migration drops them once the new code is proven live.
+
+-- 1. One row per training started for a given day.
+--
+--    id / workout_id / day_id are TEXT, not UUID: workouts.id, days.id, day_exercises.id and
+--    day_exercise_sets.id are all TEXT in this schema (the client generates them with uuidv4()
+--    and they are stored as text). user_id stays UUID because auth.users.id is UUID.
+CREATE TABLE IF NOT EXISTS day_sessions (
+  id TEXT PRIMARY KEY DEFAULT uuid_generate_v4()::text,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  workout_id TEXT NOT NULL REFERENCES workouts(id) ON DELETE CASCADE,
+  day_id TEXT NOT NULL REFERENCES days(id) ON DELETE CASCADE,
+  session_number INT NOT NULL,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(day_id, session_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_day_sessions_day_id ON day_sessions(day_id, session_number);
+CREATE INDEX IF NOT EXISTS idx_day_sessions_user_id ON day_sessions(user_id, started_at DESC);
+
+-- 2. What was actually performed, one row per set per session.
+--
+--    Points at day_exercise_id, NOT at day_exercise_sets.id: sets are added, removed and
+--    renumbered as the plan is edited, so a set id is not a stable identity for history.
+--    (day_exercise_id, set_number) is.
+--
+--    reps vs reps_raw: charting needs a number, but reps_type does not always yield one
+--    ('custom' is free text, 'time' is seconds). reps_raw always keeps what the user typed;
+--    reps is the parsed value and is NULL when it cannot be parsed.
+--
+--    reps_type and target_reps are snapshotted so historical rows keep their meaning if the
+--    exercise is later switched from e.g. reps to time.
+CREATE TABLE IF NOT EXISTS session_sets (
+  id TEXT PRIMARY KEY DEFAULT uuid_generate_v4()::text,
+  session_id TEXT NOT NULL REFERENCES day_sessions(id) ON DELETE CASCADE,
+  day_exercise_id TEXT NOT NULL REFERENCES day_exercises(id) ON DELETE CASCADE,
+  set_number INT NOT NULL,
+  weight NUMERIC,
+  reps INT,
+  reps_raw TEXT,
+  target_reps TEXT,
+  reps_type TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(session_id, day_exercise_id, set_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_sets_session_id ON session_sets(session_id);
+CREATE INDEX IF NOT EXISTS idx_session_sets_day_exercise_id ON session_sets(day_exercise_id);
+
+-- 3. RLS.
+ALTER TABLE day_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own sessions"
+  ON day_sessions FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own sessions"
+  ON day_sessions FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own sessions"
+  ON day_sessions FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own sessions"
+  ON day_sessions FOR DELETE USING (auth.uid() = user_id);
+
+ALTER TABLE session_sets ENABLE ROW LEVEL SECURITY;
+
+-- session_sets has no user_id of its own; ownership is inherited from the parent session.
+CREATE POLICY "Users can view own session sets"
+  ON session_sets FOR SELECT USING (
+    EXISTS (SELECT 1 FROM day_sessions s WHERE s.id = session_id AND s.user_id = auth.uid())
+  );
+CREATE POLICY "Users can insert own session sets"
+  ON session_sets FOR INSERT WITH CHECK (
+    EXISTS (SELECT 1 FROM day_sessions s WHERE s.id = session_id AND s.user_id = auth.uid())
+  );
+CREATE POLICY "Users can update own session sets"
+  ON session_sets FOR UPDATE USING (
+    EXISTS (SELECT 1 FROM day_sessions s WHERE s.id = session_id AND s.user_id = auth.uid())
+  );
+CREATE POLICY "Users can delete own session sets"
+  ON session_sets FOR DELETE USING (
+    EXISTS (SELECT 1 FROM day_sessions s WHERE s.id = session_id AND s.user_id = auth.uid())
+  );
+
+-- 4. Backfill.
+--
+--    Existing data supports at most two synthetic sessions per day: one from base_weight and
+--    one from the current weight. Everything in between is unrecoverable, and NO reps history
+--    can be reconstructed because reps was never recorded as a performed value — only as a
+--    target. reps is therefore left NULL and target_reps carries the prescription.
+
+--    The two date expressions below cast through ::text on purpose. days.created_at may be a
+--    timestamp while days.last_workout is an epoch in milliseconds (the client writes
+--    Date.getTime()), and either may be stored as text in this schema. Casting to text first and
+--    branching on whether the value is all digits works for both without knowing the column type.
+
+-- 4a. Session 1, from base_weight, dated at the day's creation.
+INSERT INTO day_sessions (user_id, workout_id, day_id, session_number, started_at, completed_at, notes)
+SELECT w.user_id, w.id, d.id, 1,
+       CASE WHEN d.created_at::text ~ '^\d+$'
+            THEN TO_TIMESTAMP(d.created_at::text::bigint / 1000.0)
+            ELSE d.created_at::text::timestamptz END,
+       CASE WHEN d.created_at::text ~ '^\d+$'
+            THEN TO_TIMESTAMP(d.created_at::text::bigint / 1000.0)
+            ELSE d.created_at::text::timestamptz END,
+       'Backfilled from base_weight'
+FROM days d
+JOIN workouts w ON w.id = d.workout_id
+WHERE EXISTS (
+  SELECT 1 FROM day_exercises de
+  JOIN day_exercise_sets s ON s.day_exercise_id = de.id
+  WHERE de.day_id = d.id AND s.base_weight IS NOT NULL
+)
+ON CONFLICT (day_id, session_number) DO NOTHING;
+
+INSERT INTO session_sets (session_id, day_exercise_id, set_number, weight, reps, reps_raw, target_reps, reps_type)
+SELECT ds.id, de.id, s.set_number, s.base_weight, NULL, NULL, s.reps, de.reps_type
+FROM day_sessions ds
+JOIN day_exercises de ON de.day_id = ds.day_id
+JOIN day_exercise_sets s ON s.day_exercise_id = de.id
+WHERE ds.session_number = 1
+  AND ds.notes = 'Backfilled from base_weight'
+  AND s.base_weight IS NOT NULL
+ON CONFLICT (session_id, day_exercise_id, set_number) DO NOTHING;
+
+-- 4b. Latest session, from the current weight, dated at last_workout.
+--     Only for days where the current weight actually differs from base_weight — otherwise
+--     session 1 already represents it.
+INSERT INTO day_sessions (user_id, workout_id, day_id, session_number, started_at, completed_at, notes)
+SELECT w.user_id, w.id, d.id, GREATEST(COALESCE(d.counter, 1), 2),
+       TO_TIMESTAMP(NULLIF(regexp_replace(d.last_workout::text, '\D', '', 'g'), '')::bigint / 1000.0),
+       TO_TIMESTAMP(NULLIF(regexp_replace(d.last_workout::text, '\D', '', 'g'), '')::bigint / 1000.0),
+       'Backfilled from current weight'
+FROM days d
+JOIN workouts w ON w.id = d.workout_id
+WHERE d.last_workout IS NOT NULL
+  -- started_at is NOT NULL, so skip any last_workout that does not yield a number.
+  AND NULLIF(regexp_replace(d.last_workout::text, '\D', '', 'g'), '') IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM day_exercises de
+    JOIN day_exercise_sets s ON s.day_exercise_id = de.id
+    WHERE de.day_id = d.id
+      AND s.weight IS NOT NULL
+      AND s.weight IS DISTINCT FROM s.base_weight
+  )
+ON CONFLICT (day_id, session_number) DO NOTHING;
+
+INSERT INTO session_sets (session_id, day_exercise_id, set_number, weight, reps, reps_raw, target_reps, reps_type)
+SELECT ds.id, de.id, s.set_number, s.weight, NULL, NULL, s.reps, de.reps_type
+FROM day_sessions ds
+JOIN day_exercises de ON de.day_id = ds.day_id
+JOIN day_exercise_sets s ON s.day_exercise_id = de.id
+WHERE ds.notes = 'Backfilled from current weight'
+  AND s.weight IS NOT NULL
+ON CONFLICT (session_id, day_exercise_id, set_number) DO NOTHING;
+
+COMMENT ON TABLE day_sessions IS
+  'One row per training started for a day. days.counter and days.last_workout are derivable from this table and will be dropped in phase 2.';
+COMMENT ON TABLE session_sets IS
+  'Actually performed weight and reps per set per session. day_exercise_sets remains the plan/prescription.';
+COMMENT ON COLUMN session_sets.reps IS
+  'Parsed performed reps, NULL when reps_raw is not numeric (reps_type = custom, or free text). Chart only non-NULL rows.';
+COMMENT ON COLUMN session_sets.reps_raw IS
+  'Verbatim user input, always kept even when reps could not be parsed.';

--- a/src/pages/workouts/components/exerciseContent/ExerciseContent.tsx
+++ b/src/pages/workouts/components/exerciseContent/ExerciseContent.tsx
@@ -4,9 +4,9 @@ import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { exercisesSelectors } from "../../../../store/exercisesCatalog/exercisesCatalog.selector";
 import { exercisesCatalogActions } from "../../../../store/exercisesCatalog/exercisesCatalog.action";
-import { Checkbox, Divider, Input, Select, Tooltip } from "antd";
+import { Checkbox, Divider, Input, Modal, Select, Tooltip } from "antd";
 import type { DayExercise, Set } from "../../../../store/draft/types";
-import { DeleteOutlined, InfoCircleOutlined, MinusOutlined, PlusOutlined } from "@ant-design/icons";
+import { DeleteOutlined, InfoCircleOutlined, LineChartOutlined, MinusOutlined, PlusOutlined } from "@ant-design/icons";
 import { draftSelectors } from "../../../../store/draft/draft.selectors";
 import TextArea from "antd/es/input/TextArea";
 import { v4 as uuidv4 } from "uuid";
@@ -15,6 +15,9 @@ import { RepsTypes } from "../../../../utils/constants";
 import { ExerciseSelects } from "../../../../components/exerciseSelects/ExerciseSelects";
 import { Button } from "../../../../components/button/Button";
 import { IconButton } from "../../../../components/iconButton/IconButton";
+import { ExerciseProgression } from "./progression/ExerciseProgression";
+import { SetRowHeader } from "./SetRowHeader";
+import { getSetGrid, getSetInputClassName, hasSeparateWeight } from "./setRow.styles";
 
 export interface ExerciseContentProps {
     dayId: string;
@@ -35,6 +38,7 @@ export const ExerciseContent = (props: ExerciseContentProps) => {
 
     const [dayExercise, setDayExercise] = useState<DayExercise>(props.dayExercise);
     const [isExerciseUpdated, setIsExerciseUpdated] = useState<boolean>(false);
+    const [showProgression, setShowProgression] = useState<boolean>(false);
 
     const exercises: ExerciseCatalog[] = useSelector((state: RootState) => exercisesSelectors.getExercises(state));
     const isLoadingExercises: boolean = useSelector((state: RootState) => draftSelectors.isLoadingExercises(state));
@@ -204,7 +208,7 @@ export const ExerciseContent = (props: ExerciseContentProps) => {
                                 disabled={isLoadingExercises}
                             />
                         </div>
-                        {props.isDraft && dayExercise.repsType !== "custom" && (
+                        {props.isDraft && (
                             <div className="flex justify-end gap-2 ">
                                 <IconButton icon={<MinusOutlined />} onClick={removeSet} disabled={dayExercise.sets.length === 0 || !dayExercise.repsType || isLoadingExercises} />
                                 <IconButton icon={<PlusOutlined />} onClick={addSet} disabled={!dayExercise.repsType || isLoadingExercises} />
@@ -212,44 +216,62 @@ export const ExerciseContent = (props: ExerciseContentProps) => {
                         )}
                     </div>
                 )}
+                {/* `custom` can no longer be chosen, but exercises created before it was withdrawn still
+                    carry it. Their free text stays readable so no logged workout loses its content. */}
                 {dayExercise.repsType === "custom" ? (
-                    <TextArea
-                        rows={4}
-                        value={dayExercise.customType}
-                        onChange={(input) => {
-                            setDayExercise((prevState) => {
-                                return {
-                                    ...prevState,
-                                    customType: input.target.value,
-                                };
-                            });
-                            setIsExerciseUpdated(true);
-                        }}
-                        placeholder={t("workouts.exercises.notes_placeholder")}
-                        disabled={isLoadingExercises}
-                        readOnly={props.isCurrent || props.isHistory}
-                    />
+                    <TextArea rows={4} value={dayExercise.customType} readOnly disabled={isLoadingExercises} />
                 ) : (
-                    [...(dayExercise.sets ?? [])]
+                    <div className="flex flex-col gap-2" role="group" aria-label={dayExercise.exercise?.name}>
+                        {(props.isCurrent || props.isHistory) && (dayExercise.sets ?? []).length > 0 && (
+                            <SetRowHeader repsType={dayExercise.repsType} unitLabel={getAddon()} />
+                        )}
+                        {[...(dayExercise.sets ?? [])]
                         .sort((a, b) => a.setNumber - b.setNumber)
                         .map((set: Set) => {
                             if (props.isCurrent || props.isHistory) {
                                 return (
-                                    <div key={set.id} className="flex gap-4 w-full">
-                                        <div className="w-[40%]">
-                                            <Input readOnly addonBefore={set.setNumber} value={set.reps} />
-                                        </div>
-                                        <div className="w-[60%]">
+                                    <div key={set.id} className={`${getSetGrid(dayExercise.repsType)} items-center min-h-[44px]`}>
+                                        {/* Set number: flat badge, deliberately never boxed like an input */}
+                                        <span
+                                            aria-hidden="true"
+                                            className="flex items-center justify-center h-6 w-6 rounded-full bg-[var(--bg-tertiary)] text-[12px] font-semibold text-[var(--text-secondary)] tabular-nums"
+                                        >
+                                            {set.setNumber}
+                                        </span>
+
+                                        {/* Target: read-only, so borderless and quiet. Never --text-tertiary,
+                                            which fails contrast in light mode. */}
+                                        <span id={`target-${set.id}`} className="text-center text-[13px] leading-tight tabular-nums text-[var(--text-secondary)] truncate">
+                                            {set.targetReps || "–"}
+                                        </span>
+
+                                        {/* Only `reps` exercises log reps separately; for time and max the
+                                            single value column below is the performed value. */}
+                                        {hasSeparateWeight(dayExercise.repsType) && (
                                             <Input
-                                                inputMode="decimal"
-                                                key={set.id}
-                                                addonBefore={getAddon()}
-                                                value={set.weight}
-                                                onChange={(input) => updateSet("weight", input.target.value, set.id)}
+                                                inputMode="numeric"
+                                                value={set.reps}
+                                                onChange={(input) => updateSet("reps", input.target.value, set.id)}
                                                 disabled={isLoadingExercises}
                                                 readOnly={props.isHistory}
+                                                aria-label={t("workouts.exercises.aria_performed", { set: set.setNumber })}
+                                                aria-describedby={set.targetReps ? `target-${set.id}` : undefined}
+                                                className={getSetInputClassName(props.isHistory)}
                                             />
-                                        </div>
+                                        )}
+
+                                        <Input
+                                            inputMode="decimal"
+                                            value={set.weight}
+                                            placeholder="–"
+                                            onChange={(input) => updateSet("weight", input.target.value, set.id)}
+                                            disabled={isLoadingExercises}
+                                            readOnly={props.isHistory}
+                                            aria-label={t("workouts.exercises.aria_weight", { set: set.setNumber, unit: getAddon() })}
+                                            aria-describedby={!hasSeparateWeight(dayExercise.repsType) && set.targetReps ? `target-${set.id}` : undefined}
+                                            suffix={<span className="text-[12px] text-[var(--text-secondary)] select-none pointer-events-none">{getAddon()}</span>}
+                                            className={getSetInputClassName(props.isHistory)}
+                                        />
                                     </div>
                                 );
                             }
@@ -264,7 +286,8 @@ export const ExerciseContent = (props: ExerciseContentProps) => {
                                     readOnly={dayExercise.repsType === "max"}
                                 />
                             );
-                        })
+                        })}
+                    </div>
                 )}
             </div>
             <Divider />
@@ -272,25 +295,14 @@ export const ExerciseContent = (props: ExerciseContentProps) => {
             {/* Initial Weight and Rest */}
             <div className="flex gap-4">
                 {!props.isDraft && (
-                    <Tooltip
-                        title={
-                            <div>
-                                {[...(dayExercise.sets ?? [])]
-                                    .sort((a, b) => a.setNumber - b.setNumber)
-                                    .map((set: Set) => {
-                                        return (
-                                            <div>
-                                                {set.setNumber} - {set.baseWeight}
-                                            </div>
-                                        );
-                                    })}
-                            </div>
-                        }
+                    <button
+                        type="button"
+                        onClick={() => setShowProgression(true)}
+                        className="flex items-center gap-1 border border-solid border-[var(--border-default)] rounded-md px-2 bg-transparent cursor-pointer text-[var(--text-primary)]"
                     >
-                        <div className="flex items-center border border-[#EDEDED] rounded-md px-2">
-                            <p>{t("workouts.exercises.initial")}</p>
-                        </div>
-                    </Tooltip>
+                        <LineChartOutlined />
+                        <p className="m-0">{t("workouts.exercises.progression")}</p>
+                    </button>
                 )}
                 <Input
                     readOnly={props.isCurrent || props.isHistory}
@@ -339,6 +351,10 @@ export const ExerciseContent = (props: ExerciseContentProps) => {
                     <Button label={t("workouts.exercises.save_btn")} onClick={() => props.saveExercises?.(dayExercise)} disabled={!hasValidFields()} />
                 </div>
             )}
+
+            <Modal open={showProgression} onCancel={() => setShowProgression(false)} footer={null} title={dayExercise.exercise?.name ?? t("workouts.exercises.progression")} destroyOnClose>
+                <ExerciseProgression exerciseId={dayExercise.exercise?.id} />
+            </Modal>
         </div>
     );
 };

--- a/src/pages/workouts/components/exerciseContent/SetRowHeader.tsx
+++ b/src/pages/workouts/components/exerciseContent/SetRowHeader.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from "react-i18next";
+import { getSetGrid, hasSeparateWeight } from "./setRow.styles";
+
+interface SetRowHeaderProps {
+    repsType?: string;
+    unitLabel?: string;
+}
+
+/**
+ * Rendered once per exercise, not once per set. Hoisting the static labels out of the rows is what
+ * buys the target its own column for free: the header costs ~18px once, while a per-row caption
+ * would cost ~32px on every set.
+ *
+ * Uppercase at 11px reads as a table header rather than as data, so it never competes with the
+ * numbers below it.
+ */
+export const SetRowHeader = ({ repsType, unitLabel }: SetRowHeaderProps) => {
+    const { t } = useTranslation();
+
+    const headerClass = "text-[11px] font-semibold uppercase tracking-wide text-[var(--text-secondary)] truncate";
+    const showWeight = hasSeparateWeight(repsType);
+
+    return (
+        <div className={`${getSetGrid(repsType)} items-end pb-1`}>
+            <span className={`${headerClass} text-center`}>{t("workouts.exercises.col_set")}</span>
+            <span className={`${headerClass} text-center`}>{t("workouts.exercises.col_target")}</span>
+            {/* Without a separate weight the single value column carries the unit itself,
+                so the label comes from getAddon() rather than from a reps/secs key. */}
+            <span className={`${headerClass} px-1`}>{showWeight ? t("workouts.exercises.col_performed_reps") : unitLabel}</span>
+            {showWeight && <span className={`${headerClass} px-1`}>{unitLabel}</span>}
+        </div>
+    );
+};

--- a/src/pages/workouts/components/exerciseContent/progression/ExerciseProgression.tsx
+++ b/src/pages/workouts/components/exerciseContent/progression/ExerciseProgression.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useMemo } from "react";
+import { useSelector } from "react-redux";
+import { useTranslation } from "react-i18next";
+import { Spin } from "antd";
+import { useAppDispatch, type RootState } from "../../../../../store";
+import { sessionsActions } from "../../../../../store/sessions/sessions.actions";
+import { sessionsSelectors } from "../../../../../store/sessions/sessions.selectors";
+import { groupBySession } from "./progression.utils";
+import { ExerciseProgressionTable } from "./ExerciseProgressionTable";
+
+interface ExerciseProgressionProps {
+    exerciseId?: string;
+}
+
+export const ExerciseProgression = ({ exerciseId }: ExerciseProgressionProps) => {
+    const { t } = useTranslation();
+    const dispatch = useAppDispatch();
+
+    const entries = useSelector((state: RootState) => sessionsSelectors.getProgressionForExercise(state, exerciseId));
+    const isLoading = useSelector((state: RootState) => sessionsSelectors.isLoadingProgression(state));
+
+    useEffect(() => {
+        if (exerciseId) {
+            dispatch(sessionsActions.fetchProgressionForExercise(exerciseId));
+        }
+    }, [dispatch, exerciseId]);
+
+    const sessions = useMemo(() => groupBySession(entries), [entries]);
+
+    if (isLoading && !sessions.length) {
+        return (
+            <div className="flex justify-center py-6">
+                <Spin />
+            </div>
+        );
+    }
+
+    if (!sessions.length) {
+        return <p className="text-sm text-[var(--text-secondary)] m-0">{t("workouts.progression.empty")}</p>;
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+            <ExerciseProgressionTable sessions={sessions} />
+        </div>
+    );
+};

--- a/src/pages/workouts/components/exerciseContent/progression/ExerciseProgressionTable.tsx
+++ b/src/pages/workouts/components/exerciseContent/progression/ExerciseProgressionTable.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from "react-i18next";
+import { formatSessionDate, type ProgressionSession } from "./progression.utils";
+import { getValueUnitKey } from "../../../../../utils/reps";
+
+interface ExerciseProgressionTableProps {
+    sessions: ProgressionSession[];
+}
+
+/**
+ * Always available, and the only view for reps types that cannot be charted. Newest first,
+ * which is the opposite of the chart: here the user is reading, not following a trend.
+ */
+export const ExerciseProgressionTable = ({ sessions }: ExerciseProgressionTableProps) => {
+    const { t } = useTranslation();
+
+    return (
+        <div className="flex flex-col gap-2">
+            {[...sessions].reverse().map((session) => (
+                <div key={session.sessionId} className="rounded-lg border border-solid border-[var(--border-default)] px-3 py-2">
+                    <div className="flex justify-between items-baseline mb-1">
+                        <span className="text-sm font-semibold text-[var(--text-primary)]">{formatSessionDate(session.startedAt)}</span>
+                        <span className="text-xs text-[var(--text-tertiary)]">#{session.sessionNumber}</span>
+                    </div>
+                    <div className="flex flex-wrap gap-x-4 gap-y-1">
+                        {session.sets.map((set) => (
+                            <span key={`${set.sessionId}-${set.setNumber}`} className="text-sm text-[var(--text-secondary)]">
+                                {/* The unit varies: only `reps` exercises store a weight here — time stores
+                                    seconds and max stores the reps achieved. */}
+                                <span className="text-[var(--text-tertiary)]">{set.setNumber}.</span> {set.weight ?? "-"} {t(getValueUnitKey(set.repsType))}
+                                {set.repsRaw ? ` × ${set.repsRaw}` : ""}
+                            </span>
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/src/pages/workouts/components/exerciseContent/progression/progression.utils.ts
+++ b/src/pages/workouts/components/exerciseContent/progression/progression.utils.ts
@@ -1,0 +1,67 @@
+import type { ExerciseProgressionEntry } from "../../../../../store/sessions/types";
+
+export interface ProgressionSession {
+    sessionId: string;
+    sessionNumber: number;
+    startedAt: number;
+    sets: ExerciseProgressionEntry[];
+    /** Heaviest set of the session, the point plotted on the chart. */
+    topWeight?: number;
+    /** Reps performed on the heaviest set, not the session's max reps. */
+    topReps?: number;
+    repsType?: string;
+}
+
+/** Groups the flat per-set rows into one entry per session, oldest first. */
+export const groupBySession = (entries: ExerciseProgressionEntry[]): ProgressionSession[] => {
+    const bySession = new Map<string, ProgressionSession>();
+
+    entries.forEach((entry) => {
+        const existing = bySession.get(entry.sessionId);
+        if (existing) {
+            existing.sets.push(entry);
+            return;
+        }
+        bySession.set(entry.sessionId, {
+            sessionId: entry.sessionId,
+            sessionNumber: entry.sessionNumber,
+            startedAt: entry.startedAt,
+            sets: [entry],
+            repsType: entry.repsType,
+        });
+    });
+
+    return [...bySession.values()]
+        .map((session) => {
+            const sets = [...session.sets].sort((a, b) => a.setNumber - b.setNumber);
+            const heaviest = sets.reduce<ExerciseProgressionEntry | undefined>((best, set) => {
+                if (set.weight === undefined) return best;
+                if (!best || best.weight === undefined || set.weight > best.weight) return set;
+                return best;
+            }, undefined);
+
+            return {
+                ...session,
+                sets,
+                topWeight: heaviest?.weight,
+                topReps: heaviest?.reps,
+            };
+        })
+        .sort((a, b) => a.startedAt - b.startedAt);
+};
+
+/**
+ * Reps are only chartable when at least one session recorded a parseable value. Exercises with
+ * a `custom` reps type never qualify, and backfilled sessions carry no reps at all.
+ */
+export const hasChartableReps = (sessions: ProgressionSession[]): boolean => {
+    return sessions.some((session) => session.topReps !== undefined);
+};
+
+export const hasChartableWeight = (sessions: ProgressionSession[]): boolean => {
+    return sessions.some((session) => session.topWeight !== undefined);
+};
+
+export const formatSessionDate = (startedAt: number): string => {
+    return new Date(startedAt).toLocaleDateString(undefined, { day: "2-digit", month: "short" });
+};

--- a/src/pages/workouts/components/exerciseContent/setRow.styles.ts
+++ b/src/pages/workouts/components/exerciseContent/setRow.styles.ts
@@ -1,0 +1,38 @@
+/**
+ * Only `reps` exercises have a weight distinct from the value performed. For `time` the performed
+ * value is seconds and for `max` it is the reps achieved — both have always been stored in the
+ * weight column, with getAddon() relabelling the unit. Rendering a separate reps input for those
+ * types would show an empty duplicate column and the same unit twice.
+ */
+export const hasSeparateWeight = (repsType?: string): boolean => repsType === "reps";
+
+/**
+ * Shared column template for the set rows and their header, so the two always align.
+ * 24px badge + 46px target + one or two input columns; fits a 320px viewport either way.
+ */
+export const getSetGrid = (repsType?: string): string => {
+    return hasSeparateWeight(repsType) ? "grid grid-cols-[24px_46px_1fr_1fr] gap-2" : "grid grid-cols-[24px_46px_1fr] gap-2";
+};
+
+/**
+ * Only editable values get the boxed treatment — border, elevated fill, shadow. Read-only values
+ * (set number, target) stay flat text. That containment cue is what tells the user at a glance
+ * which numbers they own; in history mode nothing is editable, so every box disappears.
+ *
+ * 16px text is load-bearing rather than cosmetic: below it, iOS Safari zooms the viewport on
+ * focus, which is unusable one-handed mid-set.
+ */
+export const getSetInputClassName = (isHistory?: boolean): string => {
+    /* A `suffix` makes antd wrap the field in an affix container, so these classes land on the
+       wrapper while the inner <input> keeps its own background — which renders as a darker
+       rectangle inside the field. The descendant rule flattens it; it does not match the reps
+       input, whose classes sit on the element itself. */
+    const base =
+        "!h-11 !rounded-lg !text-[16px] !font-medium !tabular-nums !text-[var(--text-primary)] placeholder:!text-[var(--text-tertiary)] [&_.ant-input]:!bg-transparent [&_.ant-input]:!text-[16px] [&_.ant-input]:!font-medium [&_.ant-input]:!text-[var(--text-primary)]";
+
+    if (isHistory) {
+        return `${base} !bg-transparent !border-transparent !shadow-none !px-1`;
+    }
+
+    return `${base} !px-2 !bg-[var(--bg-elevated)] !border !border-solid !border-[var(--border-default)] !shadow-[var(--shadow-sm)] focus-within:!border-[var(--brand-primary)]`;
+};

--- a/src/pages/workouts/current/components/CurrentExercisesList.tsx
+++ b/src/pages/workouts/current/components/CurrentExercisesList.tsx
@@ -1,10 +1,9 @@
-import { ArrowLeftOutlined, PlayCircleOutlined, SaveOutlined, FileTextOutlined } from "@ant-design/icons";
+import { ArrowLeftOutlined, PlayCircleOutlined, FileTextOutlined } from "@ant-design/icons";
 import { useAppDispatch, type RootState } from "../../../../store";
 import { useEffect, useState } from "react";
 import { Collapse } from "antd";
 import { SortableItem } from "../../../../components/sortableItem/SortableItem";
-import { CustomModal } from "../../../../components/customModal";
-import type { Day, DayExercise } from "../../../../store/draft/types";
+import type { Day, DayExercise, Set } from "../../../../store/draft/types";
 import { useTranslation } from "react-i18next";
 import { currentActions } from "../../../../store/current/current.actions";
 import { useNavigate, useParams } from "react-router-dom";
@@ -15,6 +14,9 @@ import { ExerciseContent } from "../../components/exerciseContent/ExerciseConten
 import { IconButton } from "../../../../components/iconButton/IconButton";
 import { draftActions } from "../../../../store/draft/draft.actions";
 import { EmptyState } from "../../../../components/emptyState/EmptyState";
+import { sessionsActions } from "../../../../store/sessions/sessions.actions";
+import { sessionsSelectors } from "../../../../store/sessions/sessions.selectors";
+import type { SessionSet } from "../../../../store/sessions/types";
 
 export const CurrentExercisesList = () => {
     const { t } = useTranslation();
@@ -26,22 +28,41 @@ export const CurrentExercisesList = () => {
 
     const [activeKey, setActiveKey] = useState<string>();
     const [mutableDayExercises, setMutableDayExercises] = useState<DayExercise[]>([]);
-    const [showConfirmSaveBase, setShowConfirmSaveBase] = useState<boolean>(false);
+
+    const activeSession = useSelector((state: RootState) => sessionsSelectors.getActiveSession(state));
 
     useEffect(() => {
-        const day = workout?.days.find((day) => day.id === dayId);
-        if (day) {
-            const mutable: DayExercise[] = [...day.dayExercises];
-            mutable.sort((a: DayExercise, b: DayExercise) => a.orderNumber - b.orderNumber);
-            setMutableDayExercises(mutable);
-        }
-    }, [workout, dayId]);
-
-    const saveAsBaseWeight = async () => {
         if (dayId) {
-            await dispatch(currentActions.saveBaseWeight({ dayExercises: mutableDayExercises, dayId }));
+            dispatch(sessionsActions.fetchSessionsForDay(dayId));
         }
-    };
+    }, [dispatch, dayId]);
+
+    /**
+     * The plan supplies the structure; the active session supplies what was actually performed.
+     * `reps` is overlaid with the session value so the input the user edits is always the
+     * performed one, while `targetReps` keeps the prescription for the placeholder.
+     */
+    useEffect(() => {
+        const day = workout?.days.find((day) => day.id === dayId);
+        if (!day) return;
+
+        const sessionSets: SessionSet[] = activeSession?.sets ?? [];
+        const mutable: DayExercise[] = day.dayExercises.map((dayExercise: DayExercise) => ({
+            ...dayExercise,
+            sets: (dayExercise.sets ?? []).map((set: Set) => {
+                const performed = sessionSets.find((sessionSet) => sessionSet.dayExerciseId === dayExercise.id && sessionSet.setNumber === set.setNumber);
+                if (!performed) return { ...set, targetReps: set.targetReps ?? set.reps };
+                return {
+                    ...set,
+                    targetReps: performed.targetReps ?? set.targetReps ?? set.reps,
+                    reps: performed.repsRaw ?? "",
+                    weight: performed.weight ?? set.weight,
+                };
+            }),
+        }));
+        mutable.sort((a: DayExercise, b: DayExercise) => a.orderNumber - b.orderNumber);
+        setMutableDayExercises(mutable);
+    }, [workout, dayId, activeSession]);
 
     const isAlreadyStarted = () => {
         const day = workout?.days.find((day) => day.id === dayId);
@@ -53,37 +74,58 @@ export const CurrentExercisesList = () => {
         }
     };
 
-    const handleStartClick = async () => {
+    /**
+     * Opens a session and seeds it from the plan. The `days` update is kept alongside it during
+     * the compatibility window: counter and last_workout are derivable from day_sessions and are
+     * dropped in phase 2 of the migration.
+     */
+    const handleStartClick = async (): Promise<string | undefined> => {
         const now = new Date();
         const newDay: Day | undefined = workout?.days.find((day) => day.id === dayId);
+        if (!newDay || !workout) return undefined;
 
-        if (newDay) {
-            await dispatch(
-                currentActions.updateDayStart({
-                    id: newDay.id,
-                    last_workout: now.getTime(),
-                    workout_id: workout!.id,
-                    name: newDay.name,
-                    counter: newDay.counter ? newDay.counter + 1 : 1,
-                    is_last: true,
-                    order: newDay.order,
-                }),
-            );
-        }
+        const started = await dispatch(
+            sessionsActions.startSession({
+                dayId: newDay.id,
+                workoutId: workout.id,
+                dayExercises: newDay.dayExercises,
+            }),
+        );
+
+        await dispatch(
+            currentActions.updateDayStart({
+                id: newDay.id,
+                last_workout: now.getTime(),
+                workout_id: workout.id,
+                name: newDay.name,
+                counter: newDay.counter ? newDay.counter + 1 : 1,
+                is_last: true,
+                order: newDay.order,
+            }),
+        );
+
+        return sessionsActions.startSession.fulfilled.match(started) ? started.payload : undefined;
     };
 
     const saveExercises = async (exercise: DayExercise) => {
         if (!workout || !dayId) return;
+
+        /* Sessions are never marked complete, so the newest one stays "active" indefinitely.
+           Whether today counts as started therefore has to come from the day itself, otherwise the
+           first edit of a new training would be written into the previous session.
+
+           When today has started, the id comes from the selector; when it has not, it comes back
+           from the thunk, because the selector is stale until startSession's fetch lands. */
+        const sessionId = isAlreadyStarted() ? activeSession?.id : await handleStartClick();
+        if (!sessionId) return;
+
         await dispatch(
-            draftActions.upsertExercises({
-                dayExercises: [exercise],
-                dayId: dayId,
-                workoutId: workout?.id,
+            sessionsActions.saveSessionSets({
+                sessionId,
+                dayId,
+                dayExercise: exercise,
             }),
         );
-        if (!isAlreadyStarted()) {
-            handleStartClick();
-        }
     };
 
     /* only used if isReadOnly is false */
@@ -168,9 +210,6 @@ export const CurrentExercisesList = () => {
                 </button>
 
                 <div className="flex gap-2 items-center">
-                    {mutableDayExercises.length > 0 && mutableDayExercises[0].sets.length > 0 && !mutableDayExercises[0].sets[0].baseWeight && (
-                        <IconButton icon={<SaveOutlined />} onClick={() => setShowConfirmSaveBase(true)} />
-                    )}
                     {isAlreadyStarted() ? (
                         <div className="text-[15px] font-medium text-[var(--text-primary)]">{t("workouts.exercises.workout_started")}</div>
                     ) : (
@@ -202,22 +241,6 @@ export const CurrentExercisesList = () => {
                     <EmptyState icon={<FileTextOutlined />} title={t("pages.current.empty_exercises_title")} description={t("pages.current.empty_exercises_description")} />
                 )}
             </div>
-
-            {/* Confirmation modal */}
-            <CustomModal
-                type="confirm"
-                open={showConfirmSaveBase}
-                onOk={() => {
-                    saveAsBaseWeight();
-                    setShowConfirmSaveBase(false);
-                }}
-                onCancel={() => {
-                    setShowConfirmSaveBase(false);
-                }}
-                okText={t("workouts.exercises.save_btn")}
-            >
-                <p className="text-[var(--text-secondary)] m-0">{t("workouts.exercises.confirm_save_base")}</p>
-            </CustomModal>
         </div>
     );
 };

--- a/src/store/current/current.actions.ts
+++ b/src/store/current/current.actions.ts
@@ -1,7 +1,6 @@
 import { createAction, createAsyncThunk } from "@reduxjs/toolkit";
 import { supabase } from "../supabaseClient";
-import type { DayExercise, Set, UpsertDayPayload, UpsertSetPayload } from "../draft/types";
-import { getNotificationApi } from "../../utils/notificationService";
+import type { UpsertDayPayload } from "../draft/types";
 
 const fetchCurrentWorkout = createAsyncThunk("data/fetchCurrentWorkout", async (_arg, thunkAPI) => {
     try {
@@ -58,40 +57,6 @@ const updateDayStart = createAsyncThunk("data/updateDayStart", async (day: Upser
     }
 });
 
-const saveBaseWeight = createAsyncThunk("data/saveBaseWeight", async (payloadData: { dayExercises: DayExercise[]; dayId: string; }, thunkAPI) => {
-    try {
-        const payloadDayExerciseSets: UpsertSetPayload[] = [];
-        payloadData.dayExercises.forEach((dayExercise: DayExercise) => {
-            dayExercise.sets.forEach((set: Set) => {
-                payloadDayExerciseSets.push({
-                    id: set.id,
-                    day_exercise_id: dayExercise.id,
-                    set_number: set.setNumber,
-                    reps: set.reps,
-                    weight: set.weight,
-                    base_weight: set.weight
-                });
-            })
-        });
-
-        await supabase.from("day_exercise_sets").upsert(payloadDayExerciseSets, {
-            onConflict: "id",
-        });
-
-        getNotificationApi().success({
-            message: `Base weights saved`,
-            placement: "bottom",
-            className: "custom-success-notification",
-        });
-
-        thunkAPI.dispatch(currentActions.fetchCurrentWorkout());
-        return;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-        return thunkAPI.rejectWithValue(error.message);
-    }
-});
-
 const showSwitcher = createAction("data/showSwitcher", (show: boolean) => {
     return {
         payload: show,
@@ -101,8 +66,7 @@ const showSwitcher = createAction("data/showSwitcher", (show: boolean) => {
 const currentActions = {
     fetchCurrentWorkout,
     updateDayStart,
-    showSwitcher,
-    saveBaseWeight
+    showSwitcher
 };
 
 export { currentActions };

--- a/src/store/draft/draft.mapper.ts
+++ b/src/store/draft/draft.mapper.ts
@@ -32,6 +32,7 @@ const getDraftWorkoutDataMapper = (response: any): Workout => {
                                 id: set.id,
                                 setNumber: set.set_number,
                                 reps: set.reps,
+                                targetReps: set.reps,
                                 weight: set.weight,
                                 baseWeight: set.base_weight
                             } as Set;

--- a/src/store/draft/types.ts
+++ b/src/store/draft/types.ts
@@ -45,7 +45,13 @@ export interface DayExercise {
 export interface Set {
     id: string;
     setNumber: number;
+    /**
+     * In draft mode this is the target. In current mode it is overlaid with the reps actually
+     * performed in the active session, so the input the user edits is always `reps`.
+     */
     reps?: string;
+    /** The plan's prescription, kept intact while `reps` carries the performed value. */
+    targetReps?: string;
     weight?: number;
     baseWeight?: number;
 }

--- a/src/store/personalBests/personalBests.actions.ts
+++ b/src/store/personalBests/personalBests.actions.ts
@@ -1,17 +1,20 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { supabase } from "../supabaseClient";
-import type { PersonalBest, PersonalBestsWorkoutResponse } from "./types";
+import type { PersonalBest } from "./types";
 import { exercisesCatalogActions } from "../exercisesCatalog/exercisesCatalog.action";
 import { fetchTrackedExerciseIds, setExerciseTracked } from "../exercisesCatalog/userExercisePrefs";
 
 /**
- * Process workout data to extract personal bests
- * Groups all weights by exercise and finds the maximum for each
+ * The heaviest weight actually performed per exercise.
  *
- * `trackedExerciseIds` comes from the current user's preferences: the catalog is shared,
- * so tracking can no longer be read off the exercise row or filtered inside the join.
+ * Read from session_sets, not from the plan: day_exercise_sets.weight is the *current* planned
+ * weight, so a deload used to erase the PR. A logged session is immutable, so it cannot.
+ *
+ * `trackedExerciseIds` comes from the current user's preferences: the catalog is shared, so
+ * tracking can no longer be read off the exercise row or filtered inside the join.
  */
-function processPersonalBests(workouts: PersonalBestsWorkoutResponse[], trackedExerciseIds: Set<string>): PersonalBest[] {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function processPersonalBests(sessionSets: any[], trackedExerciseIds: Set<string>): PersonalBest[] {
     const exerciseWeights = new Map<
         string,
         {
@@ -21,44 +24,23 @@ function processPersonalBests(workouts: PersonalBestsWorkoutResponse[], trackedE
         }
     >();
 
-    workouts.forEach((workout) => {
-        if (!workout.days || !Array.isArray(workout.days)) return;
+    (sessionSets ?? []).forEach((row) => {
+        const exercise = row?.day_exercises?.exercises_catalog;
+        if (!exercise) return;
 
-        workout.days.forEach((day) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const typedDay = day as any;
-            if (!typedDay.day_exercises || !Array.isArray(typedDay.day_exercises)) return;
+        const { id: exerciseId, name: exerciseName, category } = exercise;
+        if (!exerciseId || !exerciseName || !category) return;
+        if (!trackedExerciseIds.has(exerciseId)) return;
+        if (typeof row.weight !== "number") return;
 
-            typedDay.day_exercises.forEach((dayEx: unknown) => {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const typedDayEx = dayEx as any;
-                if (!typedDayEx.exercises_catalog) return;
-
-                const exerciseId = typedDayEx.exercises_catalog.id;
-                const exerciseName = typedDayEx.exercises_catalog.name;
-                const category = typedDayEx.exercises_catalog.category;
-
-                // Only process exercises the user tracks for personal bests
-                if (!trackedExerciseIds.has(exerciseId)) return;
-                if (!exerciseId || !exerciseName || !category) return;
-                if (!typedDayEx.day_exercise_sets || !Array.isArray(typedDayEx.day_exercise_sets)) return;
-
-                typedDayEx.day_exercise_sets.forEach((set: unknown) => {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    const typedSet = set as any;
-                    if (typedSet.weight && typeof typedSet.weight === 'number') {
-                        const current = exerciseWeights.get(exerciseId);
-                        if (!current || typedSet.weight > current.maxWeight) {
-                            exerciseWeights.set(exerciseId, {
-                                name: exerciseName,
-                                category,
-                                maxWeight: typedSet.weight,
-                            });
-                        }
-                    }
-                });
+        const current = exerciseWeights.get(exerciseId);
+        if (!current || row.weight > current.maxWeight) {
+            exerciseWeights.set(exerciseId, {
+                name: exerciseName,
+                category,
+                maxWeight: row.weight,
             });
-        });
+        }
     });
 
     return Array.from(exerciseWeights.entries())
@@ -70,6 +52,17 @@ function processPersonalBests(workouts: PersonalBestsWorkoutResponse[], trackedE
         }))
         .sort((a, b) => b.maxWeight - a.maxWeight); // Sort by weight descending
 }
+
+const SESSION_PR_SELECT = `
+    weight,
+    day_exercises!inner (
+        exercises_catalog!inner (
+            id,
+            name,
+            category
+        )
+    )
+`;
 
 /**
  * Fetch personal bests from archived workouts
@@ -85,25 +78,9 @@ const fetchWorkoutPersonalBests = createAsyncThunk(
             }
 
             const { data, error } = await supabase
-                .from("workouts")
-                .select(
-                    `
-                days (
-                    day_exercises (
-                        exercises_catalog!inner (
-                            id,
-                            name,
-                            category
-                        ),
-                        day_exercise_sets (
-                            weight
-                        )
-                    )
-                )
-            `
-                )
-                .in("status", ["archived", "published"])
-                .in("days.day_exercises.exercises_catalog.id", trackedExerciseIds);
+                .from("session_sets")
+                .select(SESSION_PR_SELECT)
+                .in("day_exercises.exercises_catalog.id", trackedExerciseIds);
 
             if (error) {
                 throw new Error("Error fetching workout personal bests");
@@ -113,7 +90,7 @@ const fetchWorkoutPersonalBests = createAsyncThunk(
                 return [];
             }
 
-            return processPersonalBests(data as PersonalBestsWorkoutResponse[], new Set(trackedExerciseIds));
+            return processPersonalBests(data, new Set(trackedExerciseIds));
         } catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : "Unknown error";
             return thunkAPI.rejectWithValue(errorMessage);
@@ -134,26 +111,7 @@ const fetchPersonalBests = createAsyncThunk("personalBests/fetchPersonalBests", 
         }
 
         // Fetch workout-derived PRs
-        const workoutPRsPromise = supabase
-            .from("workouts")
-            .select(
-                `
-                days (
-                    day_exercises (
-                        exercises_catalog!inner (
-                            id,
-                            name,
-                            category
-                        ),
-                        day_exercise_sets (
-                            weight
-                        )
-                    )
-                )
-            `
-            )
-            .in("status", ["archived", "published"])
-            .in("days.day_exercises.exercises_catalog.id", trackedExerciseIds);
+        const workoutPRsPromise = supabase.from("session_sets").select(SESSION_PR_SELECT).in("day_exercises.exercises_catalog.id", trackedExerciseIds);
 
         // Fetch manual PRs (only for tracked exercises)
         const manualPRsPromise = supabase
@@ -195,7 +153,7 @@ const fetchPersonalBests = createAsyncThunk("personalBests/fetchPersonalBests", 
         }
 
         // Process workout PRs
-        const workoutPRs = processPersonalBests((workoutResult.data || []) as PersonalBestsWorkoutResponse[], new Set(trackedExerciseIds));
+        const workoutPRs = processPersonalBests(workoutResult.data || [], new Set(trackedExerciseIds));
 
         // Process manual PRs
         const manualPRs: PersonalBest[] = (manualResult.data || []).map((item) => {

--- a/src/store/personalBests/types.ts
+++ b/src/store/personalBests/types.ts
@@ -14,12 +14,6 @@ export interface PersonalBestsState {
     isError: boolean;
 }
 
-// Response types from Supabase (using 'any' to handle Supabase's nested structure)
-export interface PersonalBestsWorkoutResponse {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    days: any[];
-}
-
 // Manual Personal Best types
 export interface ManualPersonalBestPayload {
     exerciseId: string;

--- a/src/store/reducer.config.ts
+++ b/src/store/reducer.config.ts
@@ -5,6 +5,7 @@ import { currentReducer } from "./current/current.reducer";
 import { progressesReducer } from "./progressHistory/progressHistory.reducer";
 import { historyReducer } from "./history/history.reducer";
 import { personalBestsReducer } from "./personalBests/personalBests.reducer";
+import { sessionsReducer } from "./sessions/sessions.reducer";
 
 const appReducer = combineReducers({
     ...exercisesReducer,
@@ -12,7 +13,8 @@ const appReducer = combineReducers({
     ...currentReducer,
     ...progressesReducer,
     ...historyReducer,
-    ...personalBestsReducer
+    ...personalBestsReducer,
+    ...sessionsReducer
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/store/sessions/sessions.actions.ts
+++ b/src/store/sessions/sessions.actions.ts
@@ -1,0 +1,257 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { v4 as uuidv4 } from "uuid";
+import { supabase } from "../supabaseClient";
+import type { DayExercise, Set } from "../draft/types";
+import type { DaySessionResponse, SessionSet, UpsertSessionSetPayload } from "./types";
+import { sessionsMapper } from "./sessions.mapper";
+import { parseReps } from "../../utils/reps";
+import { getNotificationApi } from "../../utils/notificationService";
+
+const SESSION_SELECT = `
+    id, day_id, workout_id, session_number, started_at, completed_at, notes, session_sets (
+        id, session_id, day_exercise_id, set_number, weight, reps, reps_raw, target_reps, reps_type, created_at
+    )
+`;
+
+const fetchSessionsForDay = createAsyncThunk("sessions/fetchSessionsForDay", async (dayId: string, thunkAPI) => {
+    try {
+        const { data, error } = await supabase.from("day_sessions").select(SESSION_SELECT).eq("day_id", dayId).order("session_number", { ascending: false });
+
+        if (error) {
+            throw new Error("Error in fetching sessions");
+        }
+
+        return sessionsMapper.getSessionsMapper((data ?? []) as unknown as DaySessionResponse[]);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+        return thunkAPI.rejectWithValue(error.message);
+    }
+});
+
+/**
+ * Opens a new session for a day and seeds one row per planned set.
+ *
+ * Seeding rule: weight comes from the plan (which holds the last performed weight thanks to the
+ * write-back in updateSessionSet), while reps come from the *previous session's actual reps*
+ * rather than the plan's target — the user wants last session's "8" pre-filled, not "8-10".
+ * On the very first session there is no prior, so reps stay empty and target_reps carries the
+ * prescription for the placeholder.
+ */
+const startSession = createAsyncThunk(
+    "sessions/startSession",
+    async (payload: { dayId: string; workoutId: string; dayExercises: DayExercise[] }, thunkAPI) => {
+        try {
+            const { data: userData } = await supabase.auth.getUser();
+            const userId = userData?.user?.id;
+            if (!userId) {
+                throw new Error("Error in starting session");
+            }
+
+            const { data: lastSessions, error: lastError } = await supabase
+                .from("day_sessions")
+                .select(SESSION_SELECT)
+                .eq("day_id", payload.dayId)
+                .order("session_number", { ascending: false })
+                .limit(1);
+
+            if (lastError) {
+                throw new Error("Error in starting session");
+            }
+
+            const previous = (lastSessions ?? [])[0] as unknown as DaySessionResponse | undefined;
+            const previousSets: SessionSet[] = previous ? sessionsMapper.getSessionMapper(previous).sets : [];
+            const sessionNumber = (previous?.session_number ?? 0) + 1;
+
+            const sessionId = uuidv4();
+            const { error: insertError } = await supabase.from("day_sessions").insert({
+                id: sessionId,
+                user_id: userId,
+                workout_id: payload.workoutId,
+                day_id: payload.dayId,
+                session_number: sessionNumber,
+                started_at: new Date().toISOString(),
+            });
+
+            if (insertError) {
+                throw new Error("Error in starting session");
+            }
+
+            const seededSets: UpsertSessionSetPayload[] = [];
+            payload.dayExercises.forEach((dayExercise: DayExercise) => {
+                (dayExercise.sets ?? []).forEach((set: Set) => {
+                    const previousSet = previousSets.find((prev) => prev.dayExerciseId === dayExercise.id && prev.setNumber === set.setNumber);
+
+                    seededSets.push({
+                        id: uuidv4(),
+                        session_id: sessionId,
+                        day_exercise_id: dayExercise.id,
+                        set_number: set.setNumber,
+                        weight: set.weight,
+                        reps: previousSet?.reps,
+                        reps_raw: previousSet?.repsRaw,
+                        target_reps: set.reps,
+                        reps_type: dayExercise.repsType,
+                    });
+                });
+            });
+
+            if (seededSets.length) {
+                const { error: setsError } = await supabase.from("session_sets").insert(seededSets);
+                if (setsError) {
+                    throw new Error("Error in starting session");
+                }
+            }
+
+            thunkAPI.dispatch(sessionsActions.fetchSessionsForDay(payload.dayId));
+            return sessionId;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            return thunkAPI.rejectWithValue(error.message);
+        }
+    }
+);
+
+/**
+ * Persists what was actually performed for a set of an exercise.
+ *
+ * The session row is authoritative; day_exercise_sets.weight is additionally updated as a
+ * denormalised "last performed" cache so the next session pre-fills without a lookup and every
+ * existing read path keeps working. The plan's reps are deliberately NOT written back: they
+ * remain the target.
+ */
+const saveSessionSets = createAsyncThunk(
+    "sessions/saveSessionSets",
+    async (payload: { sessionId: string; dayId: string; dayExercise: DayExercise }, thunkAPI) => {
+        try {
+            const { data: existing, error: existingError } = await supabase
+                .from("session_sets")
+                .select("id, set_number")
+                .eq("session_id", payload.sessionId)
+                .eq("day_exercise_id", payload.dayExercise.id);
+
+            if (existingError) {
+                throw new Error("Error in saving session");
+            }
+
+            const sessionSets: UpsertSessionSetPayload[] = (payload.dayExercise.sets ?? []).map((set: Set) => {
+                const existingSet = (existing ?? []).find((row) => row.set_number === set.setNumber);
+                return {
+                    id: existingSet?.id ?? uuidv4(),
+                    session_id: payload.sessionId,
+                    day_exercise_id: payload.dayExercise.id,
+                    set_number: set.setNumber,
+                    weight: set.weight,
+                    reps: parseReps(set.reps, payload.dayExercise.repsType) ?? undefined,
+                    reps_raw: set.reps,
+                    target_reps: set.targetReps,
+                    reps_type: payload.dayExercise.repsType,
+                };
+            });
+
+            if (sessionSets.length) {
+                const { error: upsertError } = await supabase.from("session_sets").upsert(sessionSets, { onConflict: "id" });
+                if (upsertError) {
+                    throw new Error("Error in saving session");
+                }
+            }
+
+            /* Write-back: keep the plan's weight as the last performed value.
+               `reps` here is the plan's target, never the performed value. A set whose target has
+               gone missing is skipped rather than written, so an upsert can never blank the
+               prescription. */
+            const weightWriteBack = (payload.dayExercise.sets ?? [])
+                .filter((set: Set) => set.targetReps !== undefined)
+                .map((set: Set) => ({
+                    id: set.id,
+                    day_exercise_id: payload.dayExercise.id,
+                    set_number: set.setNumber,
+                    reps: set.targetReps,
+                    weight: set.weight,
+                    base_weight: set.baseWeight,
+                }));
+
+            if (weightWriteBack.length) {
+                await supabase.from("day_exercise_sets").upsert(weightWriteBack, { onConflict: "id" });
+            }
+
+            getNotificationApi().success({
+                message: `Exercise saved`,
+                placement: "bottom",
+                className: "custom-success-notification",
+            });
+
+            thunkAPI.dispatch(sessionsActions.fetchSessionsForDay(payload.dayId));
+            return;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            getNotificationApi().error({
+                message: `Unable to save exercise`,
+                placement: "bottom",
+                className: "custom-error-notification",
+            });
+            return thunkAPI.rejectWithValue(error.message);
+        }
+    }
+);
+
+const completeSession = createAsyncThunk("sessions/completeSession", async (payload: { sessionId: string; dayId: string }, thunkAPI) => {
+    try {
+        const { error } = await supabase.from("day_sessions").update({ completed_at: new Date().toISOString() }).eq("id", payload.sessionId);
+
+        if (error) {
+            throw new Error("Error in completing session");
+        }
+
+        thunkAPI.dispatch(sessionsActions.fetchSessionsForDay(payload.dayId));
+        return;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+        return thunkAPI.rejectWithValue(error.message);
+    }
+});
+
+/** Every performed set of one catalog exercise, across all sessions, oldest first. */
+const fetchProgressionForExercise = createAsyncThunk("sessions/fetchProgressionForExercise", async (exerciseId: string, thunkAPI) => {
+    try {
+        const { data: dayExercises, error: dayExercisesError } = await supabase.from("day_exercises").select("id").eq("exercises_catalog_id", exerciseId);
+
+        if (dayExercisesError) {
+            throw new Error("Error in fetching progression");
+        }
+
+        const dayExerciseIds = (dayExercises ?? []).map((row) => row.id);
+        if (!dayExerciseIds.length) {
+            return { exerciseId, entries: [] };
+        }
+
+        const { data, error } = await supabase
+            .from("session_sets")
+            .select(
+                `
+                    id, day_exercise_id, set_number, weight, reps, reps_raw, target_reps, reps_type, day_sessions (
+                        id, session_number, started_at
+                    )
+                `
+            )
+            .in("day_exercise_id", dayExerciseIds);
+
+        if (error) {
+            throw new Error("Error in fetching progression");
+        }
+
+        return { exerciseId, entries: sessionsMapper.getProgressionMapper(data ?? []) };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+        return thunkAPI.rejectWithValue(error.message);
+    }
+});
+
+const sessionsActions = {
+    fetchSessionsForDay,
+    startSession,
+    saveSessionSets,
+    completeSession,
+    fetchProgressionForExercise,
+};
+
+export { sessionsActions };

--- a/src/store/sessions/sessions.mapper.ts
+++ b/src/store/sessions/sessions.mapper.ts
@@ -1,0 +1,67 @@
+import type { DaySession, DaySessionResponse, ExerciseProgressionEntry, SessionSet, SessionSetResponse } from "./types";
+
+const getSessionSetMapper = (set: SessionSetResponse): SessionSet => {
+    return {
+        id: set.id,
+        sessionId: set.session_id,
+        dayExerciseId: set.day_exercise_id,
+        setNumber: set.set_number,
+        weight: set.weight ?? undefined,
+        reps: set.reps ?? undefined,
+        repsRaw: set.reps_raw ?? undefined,
+        targetReps: set.target_reps ?? undefined,
+        repsType: set.reps_type ?? undefined,
+    };
+};
+
+const getSessionMapper = (session: DaySessionResponse): DaySession => {
+    return {
+        id: session.id,
+        dayId: session.day_id,
+        workoutId: session.workout_id,
+        sessionNumber: session.session_number,
+        startedAt: new Date(session.started_at).getTime(),
+        completedAt: session.completed_at ? new Date(session.completed_at).getTime() : undefined,
+        notes: session.notes,
+        sets: (session.session_sets ?? []).map(getSessionSetMapper),
+    };
+};
+
+const getSessionsMapper = (sessions: DaySessionResponse[]): DaySession[] => {
+    return (sessions ?? []).map(getSessionMapper).sort((a, b) => b.startedAt - a.startedAt);
+};
+
+/**
+ * Flattens the nested session -> sets response into one row per performed set, oldest first,
+ * which is the shape both the progression table and the chart consume.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getProgressionMapper = (rows: any[]): ExerciseProgressionEntry[] => {
+    return (rows ?? [])
+        .flatMap((row) => {
+            const session = row.day_sessions;
+            if (!session) return [];
+            return [
+                {
+                    sessionId: session.id,
+                    sessionNumber: session.session_number,
+                    startedAt: new Date(session.started_at).getTime(),
+                    dayExerciseId: row.day_exercise_id,
+                    setNumber: row.set_number,
+                    weight: row.weight ?? undefined,
+                    reps: row.reps ?? undefined,
+                    repsRaw: row.reps_raw ?? undefined,
+                    targetReps: row.target_reps ?? undefined,
+                    repsType: row.reps_type ?? undefined,
+                } as ExerciseProgressionEntry,
+            ];
+        })
+        .sort((a, b) => a.startedAt - b.startedAt || a.setNumber - b.setNumber);
+};
+
+export const sessionsMapper = {
+    getSessionMapper,
+    getSessionsMapper,
+    getSessionSetMapper,
+    getProgressionMapper,
+};

--- a/src/store/sessions/sessions.reducer.ts
+++ b/src/store/sessions/sessions.reducer.ts
@@ -1,0 +1,63 @@
+import { createReducer } from "@reduxjs/toolkit";
+import type { SessionsState } from "./types";
+import { sessionsActions } from "./sessions.actions";
+
+const sessionsState: SessionsState = {
+    sessions: [],
+    activeSessionId: undefined,
+    progressionByExercise: {},
+    isLoading: false,
+    isLoadingProgression: false,
+    isError: false,
+};
+
+export const sessionsReducer = {
+    sessions: createReducer(sessionsState, (builder) => {
+        builder
+            .addCase(sessionsActions.fetchSessionsForDay.pending, (state, action) => {
+                state.isLoading = true;
+                state.currentRequestId = action.meta.requestId;
+            })
+            .addCase(sessionsActions.fetchSessionsForDay.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.isError = false;
+                state.sessions = action.payload ?? [];
+            })
+            .addCase(sessionsActions.fetchSessionsForDay.rejected, (state) => {
+                state.isLoading = false;
+                state.isError = true;
+            })
+            .addCase(sessionsActions.startSession.pending, (state, action) => {
+                state.isLoading = true;
+                state.currentRequestId = action.meta.requestId;
+            })
+            .addCase(sessionsActions.startSession.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.isError = false;
+                state.activeSessionId = action.payload;
+            })
+            .addCase(sessionsActions.startSession.rejected, (state) => {
+                state.isLoading = false;
+                state.isError = true;
+            })
+            .addCase(sessionsActions.saveSessionSets.rejected, (state) => {
+                state.isError = true;
+            })
+            .addCase(sessionsActions.completeSession.fulfilled, (state) => {
+                state.activeSessionId = undefined;
+            })
+            .addCase(sessionsActions.fetchProgressionForExercise.pending, (state) => {
+                state.isLoadingProgression = true;
+            })
+            .addCase(sessionsActions.fetchProgressionForExercise.fulfilled, (state, action) => {
+                state.isLoadingProgression = false;
+                if (action.payload) {
+                    state.progressionByExercise[action.payload.exerciseId] = action.payload.entries;
+                }
+            })
+            .addCase(sessionsActions.fetchProgressionForExercise.rejected, (state) => {
+                state.isLoadingProgression = false;
+                state.isError = true;
+            });
+    }),
+};

--- a/src/store/sessions/sessions.selectors.ts
+++ b/src/store/sessions/sessions.selectors.ts
@@ -1,0 +1,51 @@
+import type { RootState } from "../reducer.config";
+import type { DaySession, ExerciseProgressionEntry, SessionSet } from "./types";
+
+const getSessions = (state: RootState): DaySession[] => {
+    return state.sessions.sessions;
+};
+
+/**
+ * The session set edits are written to: the one just started, or failing that the newest
+ * still-open session of the day (the user may have navigated away and come back).
+ */
+const getActiveSession = (state: RootState): DaySession | undefined => {
+    const sessions = state.sessions.sessions;
+    const activeId = state.sessions.activeSessionId;
+    if (activeId) {
+        const active = sessions.find((session: DaySession) => session.id === activeId);
+        if (active) return active;
+    }
+    return sessions.find((session: DaySession) => !session.completedAt);
+};
+
+const getActiveSessionSets = (state: RootState): SessionSet[] => {
+    return getActiveSession(state)?.sets ?? [];
+};
+
+const getProgressionForExercise = (state: RootState, exerciseId?: string): ExerciseProgressionEntry[] => {
+    if (!exerciseId) return [];
+    return state.sessions.progressionByExercise[exerciseId] ?? [];
+};
+
+const isLoading = (state: RootState): boolean => {
+    return state.sessions.isLoading;
+};
+
+const isLoadingProgression = (state: RootState): boolean => {
+    return state.sessions.isLoadingProgression;
+};
+
+const isError = (state: RootState): boolean => {
+    return state.sessions.isError;
+};
+
+export const sessionsSelectors = {
+    getSessions,
+    getActiveSession,
+    getActiveSessionSets,
+    getProgressionForExercise,
+    isLoading,
+    isLoadingProgression,
+    isError,
+};

--- a/src/store/sessions/types.ts
+++ b/src/store/sessions/types.ts
@@ -1,0 +1,105 @@
+export type SessionsState = {
+    /** Sessions of the day currently being trained or inspected, newest first. */
+    sessions: DaySession[];
+    /** The session opened by "start", i.e. the one set edits are written to. */
+    activeSessionId?: string;
+    /** Progression rows keyed by exercises_catalog id, filled on demand. */
+    progressionByExercise: Record<string, ExerciseProgressionEntry[]>;
+    isLoading: boolean;
+    isLoadingProgression: boolean;
+    isError: boolean;
+    currentRequestId?: string;
+};
+
+export interface DaySession {
+    id: string;
+    dayId: string;
+    workoutId: string;
+    sessionNumber: number;
+    startedAt: number;
+    completedAt?: number;
+    notes?: string;
+    sets: SessionSet[];
+}
+
+export interface SessionSet {
+    id: string;
+    sessionId: string;
+    dayExerciseId: string;
+    setNumber: number;
+    weight?: number;
+    /** Parsed performed reps. Undefined when repsRaw could not be reduced to a number. */
+    reps?: number;
+    /** Verbatim user input, always kept. */
+    repsRaw?: string;
+    /** Snapshot of the plan's prescription when the session ran. */
+    targetReps?: string;
+    /** Snapshot of the exercise's reps type when the session ran. */
+    repsType?: string;
+}
+
+/** One point on an exercise's progression, flattened across sessions. */
+export interface ExerciseProgressionEntry {
+    sessionId: string;
+    sessionNumber: number;
+    startedAt: number;
+    dayExerciseId: string;
+    setNumber: number;
+    weight?: number;
+    reps?: number;
+    repsRaw?: string;
+    targetReps?: string;
+    repsType?: string;
+}
+
+/* Types used for payload to be sent to be */
+export interface StartSessionPayload {
+    dayId: string;
+    workoutId: string;
+}
+
+export interface InsertSessionPayload {
+    id: string;
+    user_id: string;
+    workout_id: string;
+    day_id: string;
+    session_number: number;
+    started_at: string;
+}
+
+export interface UpsertSessionSetPayload {
+    id: string;
+    session_id: string;
+    day_exercise_id: string;
+    set_number: number;
+    weight?: number;
+    reps?: number;
+    reps_raw?: string;
+    target_reps?: string;
+    reps_type?: string;
+}
+
+/* Types used for response returned from be */
+export interface SessionSetResponse {
+    id: string;
+    session_id: string;
+    day_exercise_id: string;
+    set_number: number;
+    weight?: number;
+    reps?: number;
+    reps_raw?: string;
+    target_reps?: string;
+    reps_type?: string;
+    created_at: string;
+}
+
+export interface DaySessionResponse {
+    id: string;
+    day_id: string;
+    workout_id: string;
+    session_number: number;
+    started_at: string;
+    completed_at?: string;
+    notes?: string;
+    session_sets: SessionSetResponse[];
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -45,9 +45,5 @@ export const RepsTypes = [
     {
         value: 'max',
         label: 'Max'
-    },
-    {
-        value: 'custom',
-        label: 'Custom'
     }
 ]

--- a/src/utils/i18n/en.json
+++ b/src/utils/i18n/en.json
@@ -222,9 +222,17 @@
             "start_workout": "Start Workout",
             "reps_type_placeholder": "Select the type of reps",
             "superset": "Superset with next exercise",
-            "confirm_save_base": "Are you sure you want to save actual weights as base?",
             "workout_started": "Workout Started",
-            "initial": "Initial"
+            "progression": "Progression",
+            "col_set": "Set",
+            "col_target": "Target",
+            "col_performed_reps": "Reps",
+            "col_performed_time": "Secs",
+            "aria_performed": "Set {{set}}, performed",
+            "aria_weight": "Set {{set}}, weight in {{unit}}"
+        },
+        "progression": {
+            "empty": "No training logged yet for this exercise."
         }
     },
     "profile": {

--- a/src/utils/i18n/es.json
+++ b/src/utils/i18n/es.json
@@ -222,9 +222,17 @@
             "start_workout": "Iniciar Entrenamiento",
             "reps_type_placeholder": "Selecciona el tipo de repeticiones",
             "superset": "Superserie con el siguiente ejercicio",
-            "confirm_save_base": "¿Estás seguro de que quieres guardar los pesos actuales como base?",
             "workout_started": "Entrenamiento Iniciado",
-            "initial": "Inicial"
+            "progression": "Progresión",
+            "col_set": "Serie",
+            "col_target": "Objetivo",
+            "col_performed_reps": "Reps",
+            "col_performed_time": "Segs",
+            "aria_performed": "Serie {{set}}, realizadas",
+            "aria_weight": "Serie {{set}}, peso en {{unit}}"
+        },
+        "progression": {
+            "empty": "Aún no hay entrenamientos registrados para este ejercicio."
         }
     },
     "profile": {

--- a/src/utils/i18n/it.json
+++ b/src/utils/i18n/it.json
@@ -222,9 +222,17 @@
             "start_workout": "Inizia Allenamento",
             "reps_type_placeholder": "Seleziona il tipo di ripetizioni",
             "superset": "Superset con il prossimo esercizio",
-            "confirm_save_base": "Sei sicuro di voler salvare i pesi attuali come base?",
             "workout_started": "Allenamento Iniziato",
-            "initial": "Iniziale"
+            "progression": "Progressione",
+            "col_set": "Serie",
+            "col_target": "Obiettivo",
+            "col_performed_reps": "Rip",
+            "col_performed_time": "Sec",
+            "aria_performed": "Serie {{set}}, eseguite",
+            "aria_weight": "Serie {{set}}, peso in {{unit}}"
+        },
+        "progression": {
+            "empty": "Nessun allenamento registrato per questo esercizio."
         }
     },
     "profile": {

--- a/src/utils/reps.ts
+++ b/src/utils/reps.ts
@@ -1,0 +1,53 @@
+/**
+ * Reps are stored twice on a logged set: verbatim as the user typed them (`repsRaw`) and,
+ * when it can be derived, as a number (`reps`) so progression can be charted.
+ *
+ * A number is not always derivable, and that is by design:
+ *  - "reps" / "max" -> a plain count, chartable
+ *  - "time"         -> seconds, chartable on its own axis
+ *  - "custom"       -> free text, never chartable. Withdrawn: it can no longer be selected, but
+ *                      exercises created before then still carry it, so it stays handled here.
+ */
+export type RepsType = "reps" | "time" | "max" | "custom";
+
+/**
+ * Returns the performed reps as a number, or null when the input carries no single value.
+ *
+ * Ranges such as "8-10" are deliberately rejected: a range is a prescription, not something
+ * that was performed. When a logged value is a range it means the user did not record what
+ * they actually did, so there is nothing to chart.
+ */
+export const parseReps = (raw?: string | null, repsType?: string): number | null => {
+    if (repsType === "custom") return null;
+    if (raw === undefined || raw === null) return null;
+
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+
+    // "8-10", "8/10", "8 - 10": a range, not a performed value.
+    if (/[-/]/.test(trimmed)) return null;
+
+    const normalised = trimmed.replace(/,/g, ".");
+    const match = normalised.match(/^(\d+(?:\.\d+)?)/);
+    if (!match) return null;
+
+    const value = Number(match[1]);
+    return Number.isFinite(value) ? Math.round(value) : null;
+};
+
+/**
+ * Unit label key for the value column.
+ *
+ * Only `reps` exercises store an actual weight; `time` stores seconds and `max` stores the reps
+ * achieved, both in the same column. The label is what tells them apart.
+ */
+export const getValueUnitKey = (repsType?: string): string => {
+    switch (repsType) {
+        case "time":
+            return "workouts.exercises.secs";
+        case "max":
+            return "workouts.exercises.reps";
+        default:
+            return "workouts.exercises.kg";
+    }
+};


### PR DESCRIPTION
The plan and the record were the same object: every training overwrote day_exercise_sets.weight in place, so each session destroyed the previous one, and reps were only ever a prescription, never a record.

Keep workout -> day -> day_exercise -> sets as the template and add an append-only log beside it: day_sessions (one row per training started) and session_sets (weight and reps actually performed per set). Reps are stored both parsed and verbatim, with the reps type and target snapshotted so historical rows keep their meaning when the plan changes.

Weight pre-fills from the last session via a write-back to the plan, reps pre-fill from the previous session's actual value rather than the target.

Also:
- rework the set row into a labelled grid so the target is unambiguous, with one value column for time/max, which have no separate weight
- compute personal bests from session_sets, fixing PRs being erased by a deload
- add a per-exercise progression view
- withdraw the custom reps type from the picker, keeping legacy rows readable

Requires docs/2026-08-05/migration-training-sessions.sql.